### PR TITLE
Extracted local paths to settings.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,30 @@ Discussion in the #jorbs-spire-mod-char channel in the [Jorbs Discord](https://d
 
 ## How to build from source
 
-1. Create an environment variable named `STEAM_PATH` set to `C:/Program Files/Steam/steamapps` (or wherever you have Steam installed) 
 1. Install the Oracle Java 8 JDK (not Java 9+)
-1. Install IntelliJ IDEA (the free Community edition is fine)
-1. Clone the repository
-1. Open the project in IntelliJ IDEA:
+2. Install IntelliJ IDEA (the free Community edition is fine)
+3. Clone the repository
+4. Open the project in IntelliJ IDEA:
     1. Choose "Import Project"
     1. Choose the repository folder
     1. Select "Maven"
     1. Press next a few times, all other settings can be left at defaults 
-1. Follow the [these instructions from the StS-DefaultModBase wiki](https://github.com/Gremious/StS-DefaultModBase/wiki/Step-3:-Packaging-and-Playing-the-Default;-Writing-Your-First-Mod!) to build the mod package and debug it
+5. Create a file named settings.xml in the folder .m2 in your home directory and paste the following (replace the paths accordingly, example is for Windows - if settings.xml is already there, extend it):
+```
+<settings>
+  <profiles>
+    <profile>
+      <id>inject-local-paths</id>
+      <properties>
+        <Steam.path>C:/Program Files/Steam/steamapps</Steam.path>
+        <STS.jar.path>${Steam.path}/common/SlayTheSpire/desktop-1.0.jar</STS.jar.path>
+      </properties>
+    </profile>
+  </profiles>
+ 
+  <activeProfiles>
+    <activeProfile>inject-local-paths</activeProfile>
+  </activeProfiles>
+</settings>
+```
+6. Follow the [these instructions from the StS-DefaultModBase wiki](https://github.com/Gremious/StS-DefaultModBase/wiki/Step-3:-Packaging-and-Playing-the-Default;-Writing-Your-First-Mod!) to build the mod package and debug it

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <SlayTheSpire.version>01-23-2019</SlayTheSpire.version>
         <ModTheSpire.version>3.8.0</ModTheSpire.version>
-        <!--CHANGE THIS TO YOUR STEAM INSTALLATION-->
-        <Steam.path>${env.STEAMAPPS_PATH}</Steam.path>
     </properties>
 
     <dependencies>
@@ -23,7 +21,7 @@
             <artifactId>slaythespire</artifactId>
             <version>${SlayTheSpire.version}</version>
             <scope>system</scope>
-            <systemPath>${Steam.path}/common/SlayTheSpire/desktop-1.0.jar</systemPath>
+            <systemPath>${STS.jar.path}</systemPath>
             <!--<systemPath>${basedir}/../lib/desktop-1.0.jar</systemPath>-->
         </dependency>
         <dependency>


### PR DESCRIPTION
With these changes pom.xml does not have to be edited if the paths are not the same as in the example, and thus will not appear as a local change or even be committed by accident.