### PR TITLE
SnappedPower should be unblockable uncleansable

### DIFF
--- a/src/main/java/stsjorbsmod/actions/RemovePowersMatchingPredicateAction.java
+++ b/src/main/java/stsjorbsmod/actions/RemovePowersMatchingPredicateAction.java
@@ -1,0 +1,38 @@
+package stsjorbsmod.actions;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+
+import java.util.function.Predicate;
+
+/**
+ * Removes all powers which test true against the predicate on the target creature.
+ * For example, {@link stsjorbsmod.cards.wanderer.Amnesia} should only remove buffs and debuffs, but not the new special power type.
+ *
+ * Based on {@link com.megacrit.cardcrawl.actions.unique.RemoveAllPowersAction}
+ * @see stsjorbsmod.cards.wanderer.Amnesia
+ * @see com.megacrit.cardcrawl.powers.AbstractPower.PowerType
+ */
+public class RemovePowersMatchingPredicateAction extends AbstractGameAction {
+    private AbstractCreature c;
+    private Predicate<AbstractPower> removePowersPredicate;
+
+    public RemovePowersMatchingPredicateAction(AbstractCreature target, Predicate<AbstractPower> removePowersPredicate) {
+        super();
+        this.target = target;
+        this.removePowersPredicate = removePowersPredicate;
+    }
+
+    @Override
+    public void update() {
+        for (AbstractPower power : target.powers) {
+            if (removePowersPredicate.test(power)) {
+                AbstractDungeon.actionManager.addToTop(new RemoveSpecificPowerAction(target, target, power.ID));
+            }
+        }
+        this.isDone = true;
+    }
+}

--- a/src/main/java/stsjorbsmod/cards/wanderer/Amnesia.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Amnesia.java
@@ -16,7 +16,10 @@ import stsjorbsmod.characters.Wanderer;
 import static stsjorbsmod.JorbsMod.makeCardPath;
 
 /**
- * TODO move to curse
+ * Curse
+ * - Unplayable
+ * - At the end of player turn, Snap.
+ * - Remove player buffs and debuffs.
  */
 public class Amnesia extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(Amnesia.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/Amnesia.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Amnesia.java
@@ -3,13 +3,18 @@ package stsjorbsmod.cards.wanderer;
 import com.megacrit.cardcrawl.actions.unique.RemoveAllPowersAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.AbstractPower;
 import stsjorbsmod.JorbsMod;
+import stsjorbsmod.actions.RemovePowersMatchingPredicateAction;
 import stsjorbsmod.cards.CustomJorbsModCard;
 import stsjorbsmod.actions.SnapAction;
 import stsjorbsmod.characters.Wanderer;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
 
+/**
+ * TODO move to curse
+ */
 public class Amnesia extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(Amnesia.class.getSimpleName());
     public static final String IMG = makeCardPath("Bad_Rares/amnesia.png");
@@ -29,7 +34,7 @@ public class Amnesia extends CustomJorbsModCard {
     public void use(AbstractPlayer p, AbstractMonster _) {
         // Order matters here, since Clarities are technically powers and we want Snap to consider them.
         addToBot(new SnapAction(p));
-        addToBot(new RemoveAllPowersAction(p, upgraded));
+        addToBot(new RemovePowersMatchingPredicateAction(p, power -> power.type == AbstractPower.PowerType.BUFF || power.type == AbstractPower.PowerType.DEBUFF));
     }
 
     @Override

--- a/src/main/java/stsjorbsmod/cards/wanderer/Amnesia.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Amnesia.java
@@ -1,7 +1,10 @@
 package stsjorbsmod.cards.wanderer;
 
 import com.megacrit.cardcrawl.actions.unique.RemoveAllPowersAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardQueueItem;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 import stsjorbsmod.JorbsMod;
@@ -21,10 +24,10 @@ public class Amnesia extends CustomJorbsModCard {
 
     private static final CardRarity RARITY = CardRarity.RARE;
     private static final CardTarget TARGET = CardTarget.SELF;
-    private static final CardType TYPE = CardType.SKILL;
-    public static final CardColor COLOR = Wanderer.Enums.WANDERER_GRAY_COLOR;
+    private static final CardType TYPE = CardType.CURSE;
+    public static final CardColor COLOR = CardColor.CURSE;
 
-    private static final int COST = 0;
+    private static final int COST = -2;
 
     public Amnesia() {
         super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET);
@@ -33,15 +36,24 @@ public class Amnesia extends CustomJorbsModCard {
     @Override
     public void use(AbstractPlayer p, AbstractMonster _) {
         // Order matters here, since Clarities are technically powers and we want Snap to consider them.
-        addToBot(new SnapAction(p));
-        addToBot(new RemovePowersMatchingPredicateAction(p, power -> power.type == AbstractPower.PowerType.BUFF || power.type == AbstractPower.PowerType.DEBUFF));
+        if(dontTriggerOnUseCard) {
+            addToBot(new SnapAction(p));
+            addToBot(new RemovePowersMatchingPredicateAction(p, power -> power.type == AbstractPower.PowerType.BUFF || power.type == AbstractPower.PowerType.DEBUFF));
+        }
+    }
+
+    @Override
+    public void triggerOnEndOfTurnForPlayingCard() {
+        dontTriggerOnUseCard = true;
+        AbstractDungeon.actionManager.cardQueue.add(new CardQueueItem(this, true));
     }
 
     @Override
     public void upgrade() {
-        if (!upgraded) {
-            upgradeName();
-            upgradeDescription();
-        }
+    }
+
+    @Override
+    public AbstractCard makeCopy() {
+        return new Amnesia();
     }
 }

--- a/src/main/java/stsjorbsmod/patches/EnumsPatch.java
+++ b/src/main/java/stsjorbsmod/patches/EnumsPatch.java
@@ -1,0 +1,9 @@
+package stsjorbsmod.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireEnum;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+
+public class EnumsPatch {
+    @SpireEnum
+    public static AbstractPower.PowerType SPECIAL;
+}

--- a/src/main/java/stsjorbsmod/powers/SnappedPower.java
+++ b/src/main/java/stsjorbsmod/powers/SnappedPower.java
@@ -12,6 +12,7 @@ import com.megacrit.cardcrawl.powers.AbstractPower;
 import stsjorbsmod.JorbsMod;
 import stsjorbsmod.memories.AbstractMemory;
 import stsjorbsmod.memories.MemoryManager;
+import stsjorbsmod.patches.EnumsPatch;
 import stsjorbsmod.util.TextureLoader;
 
 import static stsjorbsmod.JorbsMod.makePowerPath;
@@ -33,7 +34,7 @@ public class SnappedPower extends AbstractPower implements CloneablePowerInterfa
 
         this.owner = owner;
 
-        type = PowerType.DEBUFF;
+        type = EnumsPatch.SPECIAL;
         isTurnBased = false;
 
         this.region128 = new TextureAtlas.AtlasRegion(tex84, 0, 0, 84, 84);

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -292,7 +292,7 @@
   },
   "stsjorbsmod:Amnesia": {
     "NAME": "Amnesia",
-    "DESCRIPTION": "Unplayable. NL At the end of your turn, remove all buffs and debuffs from self. NL stsjorbsmod:Snap."
+    "DESCRIPTION": "Unplayable. NL At the end of your turn, stsjorbsmod:Snap. NL Remove all buffs and debuffs from self."
   },
   "stsjorbsmod:Fear": {
     "NAME": "Fear",

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -292,8 +292,7 @@
   },
   "stsjorbsmod:Amnesia": {
     "NAME": "Amnesia",
-    "DESCRIPTION": "Remove all buffs and debuffs from self. NL stsjorbsmod:Snap.",
-    "UPGRADE_DESCRIPTION": "Remove all debuffs from self. NL stsjorbsmod:Snap."
+    "DESCRIPTION": "Unplayable. NL At the end of your turn, remove all buffs and debuffs from self. NL stsjorbsmod:Snap."
   },
   "stsjorbsmod:Fear": {
     "NAME": "Fear",


### PR DESCRIPTION
Artifacts doesn't block SnappedPower from applying anymore
Amnesia doesn't cleanse SnappedPower anymore
Amnesia is now an unplayable curse. card effects occur at the end of turn.
Amnesia text order to betters matches order of card actions
