### PR TITLE
Persist Wrath modifiers across play sessions

### DIFF
--- a/src/main/java/stsjorbsmod/JorbsMod.java
+++ b/src/main/java/stsjorbsmod/JorbsMod.java
@@ -16,6 +16,7 @@ import com.megacrit.cardcrawl.localization.*;
 import com.megacrit.cardcrawl.unlock.UnlockTracker;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import stsjorbsmod.cards.CardSaveData;
 import stsjorbsmod.cards.CustomJorbsModCard;
 import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.console.MemoryCommand;
@@ -132,7 +133,10 @@ public class JorbsMod implements
             e.printStackTrace();
         }
         logger.info("Done adding mod settings");
-        
+
+        logger.info("Adding save fields");
+        BaseMod.addSaveField(MOD_ID + ":CardSaveData", new CardSaveData());
+        logger.info("Done adding save fields");
     }
     
     @SuppressWarnings("unused")

--- a/src/main/java/stsjorbsmod/cards/CardSaveData.java
+++ b/src/main/java/stsjorbsmod/cards/CardSaveData.java
@@ -1,0 +1,65 @@
+package stsjorbsmod.cards;
+
+import basemod.abstracts.CustomSavableRaw;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import stsjorbsmod.JorbsMod;
+import stsjorbsmod.memories.WrathMemory;
+import stsjorbsmod.patches.WrathField;
+
+import java.util.ArrayList;
+
+public class CardSaveData implements CustomSavableRaw {
+    static class CardData {
+        Integer wrathUpgradeCount;
+
+        CardData(Integer wrathUpgradeCount) {
+            this.wrathUpgradeCount = wrathUpgradeCount;
+        }
+    };
+    private ArrayList<CardData> cardData = null;
+    private Gson saveFileGson = new Gson();
+
+    @Override
+    public JsonElement onSaveRaw() {
+        cardData = new ArrayList<>();
+        for (AbstractCard card : AbstractDungeon.player.masterDeck.group) {
+            cardData.add(new CardData(WrathField.upgradeCount.get(card)));
+        }
+        return saveFileGson.toJsonTree(cardData);
+    }
+
+    @Override
+    public void onLoadRaw(JsonElement jsonElement) {
+        try {
+            cardData = saveFileGson.fromJson(jsonElement, new TypeToken<ArrayList<CardData>>(){}.getType());
+        } catch (JsonSyntaxException e) {
+            cardData = null;
+        }
+
+        final CardGroup masterDeck = AbstractDungeon.player.masterDeck;
+
+        if (jsonElement == null) {
+            JorbsMod.logger.warn("CardSaveData found no JSON element to load");
+        } else if (cardData == null) {
+            JorbsMod.logger.error("CardSaveData failed to parse JSON");
+        } else if (cardData.size() != masterDeck.group.size()) {
+            JorbsMod.logger.error("CardSaveData has a different number of cards than the master deck");
+        } else {
+            // Restore meaning to cards from the saved addenda
+            int i = 0;
+
+            for (AbstractCard card : masterDeck.group) {
+                int wrathUpgradeCount = cardData.get(i++).wrathUpgradeCount;
+                WrathField.upgradeCount.set(card, wrathUpgradeCount);
+            }
+
+            WrathMemory.reapplyToDeck(masterDeck);
+        }
+    }
+}

--- a/src/main/java/stsjorbsmod/cards/CardSaveData.java
+++ b/src/main/java/stsjorbsmod/cards/CardSaveData.java
@@ -16,10 +16,10 @@ import java.util.ArrayList;
 
 public class CardSaveData implements CustomSavableRaw {
     static class CardData {
-        Integer wrathUpgradeCount;
+        Integer wrathEffectCount;
 
-        CardData(Integer wrathUpgradeCount) {
-            this.wrathUpgradeCount = wrathUpgradeCount;
+        CardData(Integer wrathEffectCount) {
+            this.wrathEffectCount = wrathEffectCount;
         }
     };
     private ArrayList<CardData> cardData = null;
@@ -29,7 +29,7 @@ public class CardSaveData implements CustomSavableRaw {
     public JsonElement onSaveRaw() {
         cardData = new ArrayList<>();
         for (AbstractCard card : AbstractDungeon.player.masterDeck.group) {
-            cardData.add(new CardData(WrathField.upgradeCount.get(card)));
+            cardData.add(new CardData(WrathField.effectCount.get(card)));
         }
         return saveFileGson.toJsonTree(cardData);
     }
@@ -55,8 +55,8 @@ public class CardSaveData implements CustomSavableRaw {
             int i = 0;
 
             for (AbstractCard card : masterDeck.group) {
-                int wrathUpgradeCount = cardData.get(i++).wrathUpgradeCount;
-                WrathField.upgradeCount.set(card, wrathUpgradeCount);
+                int wrathUpgradeCount = cardData.get(i++).wrathEffectCount;
+                WrathField.effectCount.set(card, wrathUpgradeCount);
             }
 
             WrathMemory.reapplyToDeck(masterDeck);

--- a/src/main/java/stsjorbsmod/cards/CardSaveData.java
+++ b/src/main/java/stsjorbsmod/cards/CardSaveData.java
@@ -29,7 +29,7 @@ public class CardSaveData implements CustomSavableRaw {
     public JsonElement onSaveRaw() {
         cardData = new ArrayList<>();
         for (AbstractCard card : AbstractDungeon.player.masterDeck.group) {
-            cardData.add(new CardData(WrathField.effectCount.get(card)));
+            cardData.add(new CardData(WrathField.wrathEffectCount.get(card)));
         }
         return saveFileGson.toJsonTree(cardData);
     }
@@ -56,7 +56,7 @@ public class CardSaveData implements CustomSavableRaw {
 
             for (AbstractCard card : masterDeck.group) {
                 int wrathUpgradeCount = cardData.get(i++).wrathEffectCount;
-                WrathField.effectCount.set(card, wrathUpgradeCount);
+                WrathField.wrathEffectCount.set(card, wrathUpgradeCount);
             }
 
             WrathMemory.reapplyToDeck(masterDeck);

--- a/src/main/java/stsjorbsmod/cards/CustomJorbsModCard.java
+++ b/src/main/java/stsjorbsmod/cards/CustomJorbsModCard.java
@@ -1,26 +1,33 @@
 package stsjorbsmod.cards;
 
 import basemod.abstracts.CustomCard;
+import basemod.abstracts.CustomSavable;
 import com.evacipated.cardcrawl.mod.stslib.StSLib;
+import com.google.gson.reflect.TypeToken;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import java.lang.reflect.Type;
 
 import static com.megacrit.cardcrawl.core.CardCrawlGame.languagePack;
 
-public abstract class CustomJorbsModCard extends CustomCard {
+public abstract class CustomJorbsModCard extends CustomCard implements
+        CustomSavable<JorbsCardPersistentData> {
     
     // Second magic number that isn't damage or block for card text display.
-    public int urMagicNumber;
-    public int baseUrMagicNumber;
-    public boolean upgradedUrMagicNumber;
-    public boolean isUrMagicNumberModified;
+    public int urMagicNumber = 0;
+    public int baseUrMagicNumber = 0;
+    public boolean upgradedUrMagicNumber = false;
+    public boolean isUrMagicNumberModified = false;
     
     // Third magic number that isn't damage or block for card text display.
-    public int metaMagicNumber;
-    public int baseMetaMagicNumber;
-    public boolean upgradedMetaMagicNumber;
-    public boolean isMetaMagicNumberModified;
+    public int metaMagicNumber = 0;
+    public int baseMetaMagicNumber = 0;
+    public boolean upgradedMetaMagicNumber = false;
+    public boolean isMetaMagicNumberModified = false;
+
+    // Persistent card changes, specially handled to cross play sessions.
+    public JorbsCardPersistentData persistentData;
 
     public CustomJorbsModCard(final String id,
                               final String img,
@@ -36,8 +43,7 @@ public abstract class CustomJorbsModCard extends CustomCard {
         isDamageModified = false;
         isBlockModified = false;
         isMagicNumberModified = false;
-        isUrMagicNumberModified = false;
-        isMetaMagicNumberModified = false;
+        persistentData = new JorbsCardPersistentData();
     }
 
     @Override
@@ -68,9 +74,9 @@ public abstract class CustomJorbsModCard extends CustomCard {
     }
 
     public void upgradeDescription() {
-        String upgradeDescription = languagePack.getCardStrings(this.cardID).UPGRADE_DESCRIPTION;
+        String upgradeDescription = languagePack.getCardStrings(cardID).UPGRADE_DESCRIPTION;
         if (upgradeDescription != null) {
-            this.rawDescription = upgradeDescription;
+            rawDescription = upgradeDescription;
         }
         initializeDescription();
     }
@@ -93,31 +99,52 @@ public abstract class CustomJorbsModCard extends CustomCard {
     // Note: this base game method is misleadingly named, it's also used when calculating card block
     @Override
     public void calculateCardDamage(AbstractMonster mo) {
-        int realBaseBlock = this.baseBlock;
-        this.baseBlock += calculateBonusBaseBlock();
-        int realBaseDamage = this.baseDamage;
-        this.baseDamage += calculateBonusBaseDamage();
+        int realBaseBlock = baseBlock;
+        baseBlock += calculateBonusBaseBlock();
+        int realBaseDamage = baseDamage;
+        baseDamage += calculateBonusBaseDamage();
 
         super.calculateCardDamage(mo);
 
-        this.baseDamage = realBaseDamage;
-        this.isDamageModified = this.damage != this.baseDamage;
-        this.baseBlock = realBaseBlock;
-        this.isBlockModified = this.block != this.baseBlock;
+        baseDamage = realBaseDamage;
+        isDamageModified = damage != baseDamage;
+        baseBlock = realBaseBlock;
+        isBlockModified = block != baseBlock;
     }
 
     @Override
     public void applyPowers() {
-        int realBaseBlock = this.baseBlock;
-        this.baseBlock += calculateBonusBaseBlock();
-        int realBaseDamage = this.baseDamage;
-        this.baseDamage += calculateBonusBaseDamage();
+        int realBaseBlock = baseBlock;
+        baseBlock += calculateBonusBaseBlock();
+        int realBaseDamage = baseDamage;
+        baseDamage += calculateBonusBaseDamage();
 
         super.applyPowers();
 
-        this.baseDamage = realBaseDamage;
-        this.isDamageModified = this.damage != this.baseDamage;
-        this.baseBlock = realBaseBlock;
-        this.isBlockModified = this.block != this.baseBlock;
+        baseDamage = realBaseDamage;
+        isDamageModified = damage != baseDamage;
+        baseBlock = realBaseBlock;
+        isBlockModified = block != baseBlock;
+    }
+
+    @Override
+    public Type savedType()
+    {
+        return new TypeToken<JorbsCardPersistentData>(){}.getType();
+    }
+
+    @Override
+    public JorbsCardPersistentData onSave() {
+        return persistentData;
+    }
+
+    @Override
+    public void onLoad(JorbsCardPersistentData value) {
+        if (value == null) {
+            return;
+        }
+
+        persistentData = value;
+        baseDamage += value.wrathBonusDamage;
     }
 }

--- a/src/main/java/stsjorbsmod/cards/CustomJorbsModCard.java
+++ b/src/main/java/stsjorbsmod/cards/CustomJorbsModCard.java
@@ -1,18 +1,14 @@
 package stsjorbsmod.cards;
 
 import basemod.abstracts.CustomCard;
-import basemod.abstracts.CustomSavable;
 import com.evacipated.cardcrawl.mod.stslib.StSLib;
-import com.google.gson.reflect.TypeToken;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
-import java.lang.reflect.Type;
 
 import static com.megacrit.cardcrawl.core.CardCrawlGame.languagePack;
 
-public abstract class CustomJorbsModCard extends CustomCard implements
-        CustomSavable<JorbsCardPersistentData> {
+public abstract class CustomJorbsModCard extends CustomCard {
     
     // Second magic number that isn't damage or block for card text display.
     public int urMagicNumber = 0;
@@ -25,9 +21,6 @@ public abstract class CustomJorbsModCard extends CustomCard implements
     public int baseMetaMagicNumber = 0;
     public boolean upgradedMetaMagicNumber = false;
     public boolean isMetaMagicNumberModified = false;
-
-    // Persistent card changes, specially handled to cross play sessions.
-    public JorbsCardPersistentData persistentData;
 
     public CustomJorbsModCard(final String id,
                               final String img,
@@ -43,7 +36,6 @@ public abstract class CustomJorbsModCard extends CustomCard implements
         isDamageModified = false;
         isBlockModified = false;
         isMagicNumberModified = false;
-        persistentData = new JorbsCardPersistentData();
     }
 
     @Override
@@ -125,26 +117,5 @@ public abstract class CustomJorbsModCard extends CustomCard implements
         isDamageModified = damage != baseDamage;
         baseBlock = realBaseBlock;
         isBlockModified = block != baseBlock;
-    }
-
-    @Override
-    public Type savedType()
-    {
-        return new TypeToken<JorbsCardPersistentData>(){}.getType();
-    }
-
-    @Override
-    public JorbsCardPersistentData onSave() {
-        return persistentData;
-    }
-
-    @Override
-    public void onLoad(JorbsCardPersistentData value) {
-        if (value == null) {
-            return;
-        }
-
-        persistentData = value;
-        baseDamage += value.wrathBonusDamage;
     }
 }

--- a/src/main/java/stsjorbsmod/cards/JorbsCardPersistentData.java
+++ b/src/main/java/stsjorbsmod/cards/JorbsCardPersistentData.java
@@ -1,5 +1,0 @@
-package stsjorbsmod.cards;
-
-public class JorbsCardPersistentData {
-    public int wrathBonusDamage = 0;
-}

--- a/src/main/java/stsjorbsmod/cards/JorbsCardPersistentData.java
+++ b/src/main/java/stsjorbsmod/cards/JorbsCardPersistentData.java
@@ -1,0 +1,5 @@
+package stsjorbsmod.cards;
+
+public class JorbsCardPersistentData {
+    public int wrathBonusDamage = 0;
+}

--- a/src/main/java/stsjorbsmod/memories/WrathMemory.java
+++ b/src/main/java/stsjorbsmod/memories/WrathMemory.java
@@ -25,7 +25,7 @@ public class WrathMemory extends AbstractMemory {
 
     public static void reapplyToDeck(CardGroup deck) {
         for (AbstractCard card : deck.group) {
-            final int upgradeCount = WrathField.upgradeCount.get(card);
+            final int upgradeCount = WrathField.effectCount.get(card);
             if (!isUpgradeCandidate(card) && (upgradeCount > 0)) {
                 JorbsMod.logger.error("Wrath upgrade count modified for an ineligible card");
             }
@@ -95,18 +95,14 @@ public class WrathMemory extends AbstractMemory {
         AbstractCard masterCard = StSLib.getMasterDeckEquivalent(card);
         if (masterCard != null) {
             masterCard.baseDamage += DAMAGE_INCREASE_PER_KILL;
+            WrathField.effectCount.set(masterCard, WrathField.effectCount.get(masterCard) + 1);
             masterCard.superFlash();
             cardToShowForVfx = masterCard;
-
-            // Because it is the master deck that's saved, we need to track
-            // the card's deviation from base for potential future loads.
-            int count = WrathField.upgradeCount.get(masterCard);
-            WrathField.upgradeCount.set(masterCard, count + 1);
         }
 
         for (AbstractCard instance : GetAllInBattleInstances.get(card.uuid)) {
-            instance.isDamageModified = true;
             instance.baseDamage += DAMAGE_INCREASE_PER_KILL;
+            WrathField.effectCount.set(instance, WrathField.effectCount.get(instance) + 1);
             instance.applyPowers();
         }
 

--- a/src/main/java/stsjorbsmod/memories/WrathMemory.java
+++ b/src/main/java/stsjorbsmod/memories/WrathMemory.java
@@ -3,7 +3,6 @@ package stsjorbsmod.memories;
 import com.evacipated.cardcrawl.mod.stslib.StSLib;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.AbstractCard.CardType;
-import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
@@ -11,6 +10,7 @@ import com.megacrit.cardcrawl.helpers.GetAllInBattleInstances;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.MinionPower;
 import stsjorbsmod.JorbsMod;
+import stsjorbsmod.cards.CustomJorbsModCard;
 import stsjorbsmod.util.EffectUtils;
 
 public class WrathMemory extends AbstractMemory {
@@ -86,9 +86,16 @@ public class WrathMemory extends AbstractMemory {
             masterCard.baseDamage += DAMAGE_INCREASE_PER_KILL;
             masterCard.superFlash();
             cardToShowForVfx = masterCard;
+
+            // Because it is the master deck that's saved, we need to track
+            // the card's deviation from base for potential future loads.
+            if (masterCard instanceof CustomJorbsModCard) {
+                ((CustomJorbsModCard) masterCard).persistentData.wrathBonusDamage += DAMAGE_INCREASE_PER_KILL;
+            }
         }
 
         for (AbstractCard instance : GetAllInBattleInstances.get(card.uuid)) {
+            instance.isDamageModified = true;
             instance.baseDamage += DAMAGE_INCREASE_PER_KILL;
             instance.applyPowers();
         }

--- a/src/main/java/stsjorbsmod/memories/WrathMemory.java
+++ b/src/main/java/stsjorbsmod/memories/WrathMemory.java
@@ -25,7 +25,7 @@ public class WrathMemory extends AbstractMemory {
 
     public static void reapplyToDeck(CardGroup deck) {
         for (AbstractCard card : deck.group) {
-            final int upgradeCount = WrathField.effectCount.get(card);
+            final int upgradeCount = WrathField.wrathEffectCount.get(card);
             if (!isUpgradeCandidate(card) && (upgradeCount > 0)) {
                 JorbsMod.logger.error("Wrath upgrade count modified for an ineligible card");
             }
@@ -95,14 +95,14 @@ public class WrathMemory extends AbstractMemory {
         AbstractCard masterCard = StSLib.getMasterDeckEquivalent(card);
         if (masterCard != null) {
             masterCard.baseDamage += DAMAGE_INCREASE_PER_KILL;
-            WrathField.effectCount.set(masterCard, WrathField.effectCount.get(masterCard) + 1);
+            WrathField.wrathEffectCount.set(masterCard, WrathField.wrathEffectCount.get(masterCard) + 1);
             masterCard.superFlash();
             cardToShowForVfx = masterCard;
         }
 
         for (AbstractCard instance : GetAllInBattleInstances.get(card.uuid)) {
             instance.baseDamage += DAMAGE_INCREASE_PER_KILL;
-            WrathField.effectCount.set(instance, WrathField.effectCount.get(instance) + 1);
+            WrathField.wrathEffectCount.set(instance, WrathField.wrathEffectCount.get(instance) + 1);
             instance.applyPowers();
         }
 

--- a/src/main/java/stsjorbsmod/memories/WrathMemory.java
+++ b/src/main/java/stsjorbsmod/memories/WrathMemory.java
@@ -3,6 +3,7 @@ package stsjorbsmod.memories;
 import com.evacipated.cardcrawl.mod.stslib.StSLib;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.AbstractCard.CardType;
+import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
@@ -10,13 +11,27 @@ import com.megacrit.cardcrawl.helpers.GetAllInBattleInstances;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.MinionPower;
 import stsjorbsmod.JorbsMod;
-import stsjorbsmod.cards.CustomJorbsModCard;
+import stsjorbsmod.patches.WrathField;
 import stsjorbsmod.util.EffectUtils;
 
 public class WrathMemory extends AbstractMemory {
     public static final StaticMemoryInfo STATIC = StaticMemoryInfo.Load(WrathMemory.class);
 
     private static final int DAMAGE_INCREASE_PER_KILL = 1;
+
+    private static boolean isUpgradeCandidate(AbstractCard c) {
+        return c.type == CardType.ATTACK && c.baseDamage > 0;
+    }
+
+    public static void reapplyToDeck(CardGroup deck) {
+        for (AbstractCard card : deck.group) {
+            final int upgradeCount = WrathField.upgradeCount.get(card);
+            if (!isUpgradeCandidate(card) && (upgradeCount > 0)) {
+                JorbsMod.logger.error("Wrath upgrade count modified for an ineligible card");
+            }
+            card.baseDamage += DAMAGE_INCREASE_PER_KILL * upgradeCount;
+        }
+    }
 
     public WrathMemory(final AbstractCreature owner, boolean isClarified) {
         super(STATIC, MemoryType.SIN, owner, isClarified);
@@ -32,10 +47,6 @@ public class WrathMemory extends AbstractMemory {
     private void setCardDescriptionPlaceholder(AbstractCard c) {
         String text = c != null ? c.name : "none";
         setDescriptionPlaceholder("!C!", text);
-    }
-
-    private boolean isUpgradeCandidate(AbstractCard c) {
-        return c.type == CardType.ATTACK && c.baseDamage > 0;
     }
 
     private AbstractCard getCardToUpgrade() {
@@ -89,9 +100,8 @@ public class WrathMemory extends AbstractMemory {
 
             // Because it is the master deck that's saved, we need to track
             // the card's deviation from base for potential future loads.
-            if (masterCard instanceof CustomJorbsModCard) {
-                ((CustomJorbsModCard) masterCard).persistentData.wrathBonusDamage += DAMAGE_INCREASE_PER_KILL;
-            }
+            int count = WrathField.upgradeCount.get(masterCard);
+            WrathField.upgradeCount.set(masterCard, count + 1);
         }
 
         for (AbstractCard instance : GetAllInBattleInstances.get(card.uuid)) {

--- a/src/main/java/stsjorbsmod/patches/AbstractCardMakeStatEquivalentCopyPatch.java
+++ b/src/main/java/stsjorbsmod/patches/AbstractCardMakeStatEquivalentCopyPatch.java
@@ -1,0 +1,38 @@
+package stsjorbsmod.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import stsjorbsmod.JorbsMod;
+import stsjorbsmod.cards.CustomJorbsModCard;
+
+@SpirePatch(
+        clz = AbstractCard.class,
+        method = "makeStatEquivalentCopy"
+)
+public class AbstractCardMakeStatEquivalentCopyPatch {
+    private final static String Name = AbstractCardMakeStatEquivalentCopyPatch.class.getSimpleName() + ": ";
+    
+    @SpirePostfixPatch
+    // Copy every field we add to cards that lasts more than an action
+    public static AbstractCard Postfix(AbstractCard __result, AbstractCard __this) {
+        WrathField.effectCount.set(__result, WrathField.effectCount.get(__this) + 1);
+
+        if ((__result instanceof CustomJorbsModCard) != (__this instanceof CustomJorbsModCard)) {
+            JorbsMod.logger.error(Name + "source and copy aren't both JorbsMod cards");
+        } else if (__result instanceof CustomJorbsModCard) {
+            CustomJorbsModCard card = (CustomJorbsModCard) __result;
+            CustomJorbsModCard source = (CustomJorbsModCard) __this;
+            card.urMagicNumber = source.urMagicNumber;
+            card.baseUrMagicNumber = source.baseUrMagicNumber;
+            card.isUrMagicNumberModified = source.isUrMagicNumberModified;
+            card.upgradedUrMagicNumber = source.upgradedUrMagicNumber;
+            card.metaMagicNumber = source.metaMagicNumber;
+            card.baseMetaMagicNumber = source.baseMetaMagicNumber;
+            card.isMetaMagicNumberModified = source.isMetaMagicNumberModified;
+            card.upgradedMetaMagicNumber = source.upgradedMetaMagicNumber;
+        }
+        
+        return __result;
+    }
+}

--- a/src/main/java/stsjorbsmod/patches/AbstractCardMakeStatEquivalentCopyPatch.java
+++ b/src/main/java/stsjorbsmod/patches/AbstractCardMakeStatEquivalentCopyPatch.java
@@ -16,7 +16,7 @@ public class AbstractCardMakeStatEquivalentCopyPatch {
     @SpirePostfixPatch
     // Copy every field we add to cards that lasts more than an action
     public static AbstractCard Postfix(AbstractCard __result, AbstractCard __this) {
-        WrathField.effectCount.set(__result, WrathField.effectCount.get(__this) + 1);
+        WrathField.effectCount.set(__result, WrathField.effectCount.get(__this));
 
         if ((__result instanceof CustomJorbsModCard) != (__this instanceof CustomJorbsModCard)) {
             JorbsMod.logger.error(Name + "source and copy aren't both JorbsMod cards");

--- a/src/main/java/stsjorbsmod/patches/AbstractCardMakeStatEquivalentCopyPatch.java
+++ b/src/main/java/stsjorbsmod/patches/AbstractCardMakeStatEquivalentCopyPatch.java
@@ -16,7 +16,7 @@ public class AbstractCardMakeStatEquivalentCopyPatch {
     @SpirePostfixPatch
     // Copy every field we add to cards that lasts more than an action
     public static AbstractCard Postfix(AbstractCard __result, AbstractCard __this) {
-        WrathField.effectCount.set(__result, WrathField.effectCount.get(__this));
+        WrathField.wrathEffectCount.set(__result, WrathField.wrathEffectCount.get(__this));
 
         if ((__result instanceof CustomJorbsModCard) != (__this instanceof CustomJorbsModCard)) {
             JorbsMod.logger.error(Name + "source and copy aren't both JorbsMod cards");

--- a/src/main/java/stsjorbsmod/patches/WrathField.java
+++ b/src/main/java/stsjorbsmod/patches/WrathField.java
@@ -10,5 +10,5 @@ import com.megacrit.cardcrawl.cards.AbstractCard;
 )
 public class WrathField {
     @SuppressWarnings("unchecked")
-    public static SpireField<Integer> upgradeCount = new SpireField(() -> 0);
+    public static SpireField<Integer> effectCount = new SpireField(() -> 0);
 }

--- a/src/main/java/stsjorbsmod/patches/WrathField.java
+++ b/src/main/java/stsjorbsmod/patches/WrathField.java
@@ -10,5 +10,5 @@ import com.megacrit.cardcrawl.cards.AbstractCard;
 )
 public class WrathField {
     @SuppressWarnings("unchecked")
-    public static SpireField<Integer> effectCount = new SpireField(() -> 0);
+    public static SpireField<Integer> wrathEffectCount = new SpireField(() -> 0);
 }

--- a/src/main/java/stsjorbsmod/patches/WrathField.java
+++ b/src/main/java/stsjorbsmod/patches/WrathField.java
@@ -1,0 +1,14 @@
+package stsjorbsmod.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+@SpirePatch(
+        clz = AbstractCard.class,
+        method = SpirePatch.CLASS
+)
+public class WrathField {
+    @SuppressWarnings("unchecked")
+    public static SpireField<Integer> upgradeCount = new SpireField(() -> 0);
+}


### PR DESCRIPTION
Cards save their ID, number of upgrades, and their misc field by
default. To save how Wrath modifies a card's base damage, we
implement the CustomSavable interface on all of our cards and
introduce a new class to track persistent changes. Currently the only
value is how much Wrath modifies a card. Persistent changes are
re-applied to cards upon loading.

REVIEW: The addition of the save class seems like extra work for what's just one field. When I originally had it implemented as an Integer, I was seeing odd behavior, where the value seemed to be lost over time. I was wondering if something about a common class like Integer caused problems with deserializing the JSON in the mainline code. I never root caused the problem, but after changing to a unique class I haven't been able to repro the behavior.