### PR TITLE
Fix Wrath to stack with Ritual Dagger

### DIFF
--- a/src/main/java/stsjorbsmod/cards/CardSaveData.java
+++ b/src/main/java/stsjorbsmod/cards/CardSaveData.java
@@ -55,11 +55,9 @@ public class CardSaveData implements CustomSavableRaw {
             int i = 0;
 
             for (AbstractCard card : masterDeck.group) {
-                int wrathUpgradeCount = cardData.get(i++).wrathEffectCount;
-                WrathField.wrathEffectCount.set(card, wrathUpgradeCount);
+                int wrathEffectCount = cardData.get(i++).wrathEffectCount;
+                WrathMemory.reapplyToLoadedCard(card, wrathEffectCount);
             }
-
-            WrathMemory.reapplyToDeck(masterDeck);
         }
     }
 }


### PR DESCRIPTION
Ritual Dagger is the only main game attack that tracks damage
differently. We handle it as a special case, rather than trying to
be general for whatever other mods might do.

Resolves #109.

I really should just sleep and push in the morning, but I want that feeling of accomplishment. No matter that it takes twice as long at this time of day to check the work.