### PR TITLE
Update Animate Objects

### DIFF
--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -188,8 +188,7 @@
   },
   "stsjorbsmod:AnimateObjects": {
     "NAME": "Animate Objects",
-    "DESCRIPTION": "Deal !D! damage to ALL enemies, !M! for each card in your draw and discard piles that didn't start the combat in your deck.",
-    "UPGRADE_DESCRIPTION": "Deal !D! damage to ALL enemies, !M! for each card in your draw and discard piles that didn't start the combat in your deck. Add an Animate Objects to your discard pile."
+    "DESCRIPTION": "Deal !D! damage to ALL enemies for each non-exhausted card that didn't start the combat in your deck."
   },
   "stsjorbsmod:ColorSpray": {
     "NAME": "Color Spray",


### PR DESCRIPTION
From the spreadsheet for current intended card effects, remove the
upgrade ability to copy itself. Change the damage to hit once per
eligible card found. Modify description to match new behavior.

Resolves #73.