### PR TITLE
Fix card interaction with Nilry's Codex

### DIFF
--- a/src/main/java/stsjorbsmod/cards/wanderer/ArcaneForm.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/ArcaneForm.java
@@ -6,11 +6,11 @@ import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import stsjorbsmod.JorbsMod;
 import stsjorbsmod.actions.GainSpecificClarityAction;
 import stsjorbsmod.cards.CustomJorbsModCard;
-import stsjorbsmod.actions.RememberSpecificMemoryAction;
 import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.*;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
+import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
 import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
 
 public class ArcaneForm extends CustomJorbsModCard {
@@ -28,6 +28,7 @@ public class ArcaneForm extends CustomJorbsModCard {
     public ArcaneForm() {
         super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET);
 
+        tags.add(PERSISTENT_POSITIVE_EFFECT);
         tags.add(REMEMBER_MEMORY);
         tags.add(BaseModCardTags.FORM);
     }
@@ -46,7 +47,6 @@ public class ArcaneForm extends CustomJorbsModCard {
         if (!upgraded) {
             upgradeName();
             upgradeBaseCost(UPGRADED_COST);
-            initializeDescription();
         }
     }
 }

--- a/src/main/java/stsjorbsmod/cards/wanderer/CorpseExplosion_Wanderer.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/CorpseExplosion_Wanderer.java
@@ -13,6 +13,7 @@ import stsjorbsmod.memories.WrathMemory;
 import stsjorbsmod.patches.EntombedField;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
+import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
 import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
 
 public class CorpseExplosion_Wanderer extends CustomJorbsModCard {
@@ -35,6 +36,7 @@ public class CorpseExplosion_Wanderer extends CustomJorbsModCard {
         exhaust = true;
         isEthereal = true;
 
+        tags.add(PERSISTENT_POSITIVE_EFFECT);
         tags.add(REMEMBER_MEMORY);
     }
 
@@ -49,7 +51,6 @@ public class CorpseExplosion_Wanderer extends CustomJorbsModCard {
         if (!upgraded) {
             upgradeName();
             upgradeDamage(UPGRADE_PLUS_DAMAGE);
-            initializeDescription();
         }
     }
 }

--- a/src/main/java/stsjorbsmod/cards/wanderer/Determination.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Determination.java
@@ -11,6 +11,7 @@ import stsjorbsmod.memories.PrideMemory;
 import stsjorbsmod.powers.FragilePower;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
+import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
 import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
 
 public class Determination extends CustomJorbsModCard {
@@ -30,6 +31,7 @@ public class Determination extends CustomJorbsModCard {
         super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET);
         magicNumber = baseMagicNumber = TURNS_UNTIL_SNAP;
 
+        tags.add(PERSISTENT_POSITIVE_EFFECT);
         tags.add(REMEMBER_MEMORY);
     }
 

--- a/src/main/java/stsjorbsmod/cards/wanderer/Feast.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Feast.java
@@ -10,9 +10,9 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.GluttonyMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
+import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
 import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
 
-// 1: Remember Gluttony. Draw 3(4) cards. Exhaust.
 public class Feast extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(Feast.class.getSimpleName());
     public static final String IMG = makeCardPath("Manipulation_Rares/feast.png");
@@ -31,6 +31,7 @@ public class Feast extends CustomJorbsModCard {
         magicNumber = baseMagicNumber = DRAW;
         exhaust = true;
 
+        tags.add(PERSISTENT_POSITIVE_EFFECT);
         tags.add(REMEMBER_MEMORY);
     }
 
@@ -45,7 +46,6 @@ public class Feast extends CustomJorbsModCard {
         if (!upgraded) {
             upgradeName();
             upgradeBaseCost(UPGRADE_COST);
-            initializeDescription();
         }
     }
 }

--- a/src/main/java/stsjorbsmod/cards/wanderer/LocateObject.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/LocateObject.java
@@ -10,6 +10,7 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.GreedMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
+import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
 import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
 
 public class LocateObject extends CustomJorbsModCard {
@@ -30,6 +31,7 @@ public class LocateObject extends CustomJorbsModCard {
         magicNumber = baseMagicNumber = DRAW;
         exhaust = true;
 
+        tags.add(PERSISTENT_POSITIVE_EFFECT);
         tags.add(REMEMBER_MEMORY);
     }
 
@@ -44,7 +46,6 @@ public class LocateObject extends CustomJorbsModCard {
         if (!upgraded) {
             upgradeName();
             upgradeMagicNumber(UPGRADE_PLUS_DRAW);
-            initializeDescription();
         }
     }
 }

--- a/src/main/java/stsjorbsmod/cards/wanderer/Mending.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Mending.java
@@ -5,11 +5,11 @@ import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import stsjorbsmod.JorbsMod;
 import stsjorbsmod.cards.CustomJorbsModCard;
-import stsjorbsmod.actions.EndTurnNowAction;
 import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.MemoryManager;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
+import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
 
 public class Mending extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(Mending.class.getSimpleName());
@@ -28,6 +28,8 @@ public class Mending extends CustomJorbsModCard {
         super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET);
         magicNumber = baseMagicNumber = HEAL_PER_CLARITY;
         exhaust = true;
+
+        tags.add(CardTags.HEALING);
     }
 
     @Override
@@ -41,7 +43,6 @@ public class Mending extends CustomJorbsModCard {
         if (!upgraded) {
             upgradeName();
             upgradeMagicNumber(UPGRADE_PLUS_HEAL_PER_CLARITY);
-            initializeDescription();
         }
     }
 }

--- a/src/main/java/stsjorbsmod/cards/wanderer/SmithingStrike.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/SmithingStrike.java
@@ -12,6 +12,7 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.WrathMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
+import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
 import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
 
 public class SmithingStrike extends CustomJorbsModCard {
@@ -31,7 +32,8 @@ public class SmithingStrike extends CustomJorbsModCard {
         super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET);
         baseDamage = DAMAGE;
 
-        this.tags.add(REMEMBER_MEMORY);
+        tags.add(PERSISTENT_POSITIVE_EFFECT);
+        tags.add(REMEMBER_MEMORY);
     }
 
     @Override
@@ -45,7 +47,6 @@ public class SmithingStrike extends CustomJorbsModCard {
         if (!upgraded) {
             upgradeName();
             upgradeDamage(UPGRADE_PLUS_DMG);
-            initializeDescription();
         }
     }
 }

--- a/src/main/java/stsjorbsmod/characters/Wanderer.java
+++ b/src/main/java/stsjorbsmod/characters/Wanderer.java
@@ -62,6 +62,11 @@ public class Wanderer extends CustomPlayer {
         public static CardLibrary.LibraryType WANDERER_LIBRARY_COLOR;
         @SpireEnum(name = "REMEMBER_MEMORY")
         public static AbstractCard.CardTags REMEMBER_MEMORY;
+        // Use on a card that brings in a possible beneficial effect that lasts longer than the combat and isn't
+        // directly healing or gaining Max HP. If the effect has indirect healing, such as adding a second effect
+        // that conditionally heals or grants Max HP, do use this card tag instead of HEALING.
+        @SpireEnum(name = "PERSISTENT_POSITIVE_EFFECT")
+        public static AbstractCard.CardTags PERSISTENT_POSITIVE_EFFECT;
     }
     
     // Note: These have to live in a separate static subclass to ensure the BaseMode.addColor call can happen before the

--- a/src/main/java/stsjorbsmod/patches/FilterRandomCardGenerationPatch.java
+++ b/src/main/java/stsjorbsmod/patches/FilterRandomCardGenerationPatch.java
@@ -26,8 +26,8 @@ public class FilterRandomCardGenerationPatch {
                 localvars = "list"
         )
         @SuppressWarnings("unchecked")
-        public static void patch(@ByRef ArrayList[] list) {
-            RemovePersistentPositiveEffects(list[0]);
+        public static void patch(ArrayList list) {
+            RemovePersistentPositiveEffects(list);
         }
     }
 
@@ -42,8 +42,8 @@ public class FilterRandomCardGenerationPatch {
                 localvars = "list"
         )
         @SuppressWarnings("unchecked")
-        public static void patch(AbstractCard.CardType type, @ByRef ArrayList[] list) {
-            RemovePersistentPositiveEffects(list[0]);
+        public static void patch(AbstractCard.CardType type, ArrayList list) {
+            RemovePersistentPositiveEffects(list);
         }
     }
 
@@ -58,8 +58,8 @@ public class FilterRandomCardGenerationPatch {
                 localvars = "list"
         )
         @SuppressWarnings("unchecked")
-        public static void patch(Random rng, @ByRef ArrayList[] list) {
-            RemovePersistentPositiveEffects(list[0]);
+        public static void patch(Random rng, ArrayList list) {
+            RemovePersistentPositiveEffects(list);
         }
     }
 

--- a/src/main/java/stsjorbsmod/patches/FilterRandomCardGenerationPatch.java
+++ b/src/main/java/stsjorbsmod/patches/FilterRandomCardGenerationPatch.java
@@ -1,0 +1,75 @@
+package stsjorbsmod.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.random.Random;
+import javassist.CtBehavior;
+
+import java.util.ArrayList;
+
+import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
+
+public class FilterRandomCardGenerationPatch {
+    private static void RemovePersistentPositiveEffects(ArrayList list) {
+        list.removeIf(o -> ((AbstractCard) o).hasTag(PERSISTENT_POSITIVE_EFFECT));
+    }
+
+    @SpirePatch(
+            clz = AbstractDungeon.class,
+            method = "returnTrulyRandomCardInCombat",
+            paramtypez = { }
+    )
+    public static class AbstractDungeon_returnTrulyRandomCardInCombat_1 {
+        @SpireInsertPatch(
+                locator = Locator.class,
+                localvars = "list"
+        )
+        @SuppressWarnings("unchecked")
+        public static void patch(@ByRef ArrayList[] list) {
+            RemovePersistentPositiveEffects(list[0]);
+        }
+    }
+
+    @SpirePatch(
+            clz = AbstractDungeon.class,
+            method = "returnTrulyRandomCardInCombat",
+            paramtypez = { AbstractCard.CardType.class }
+    )
+    public static class AbstractDungeon_returnTrulyRandomCardInCombat_2 {
+        @SpireInsertPatch(
+                locator = Locator.class,
+                localvars = "list"
+        )
+        @SuppressWarnings("unchecked")
+        public static void patch(AbstractCard.CardType type, @ByRef ArrayList[] list) {
+            RemovePersistentPositiveEffects(list[0]);
+        }
+    }
+
+    @SpirePatch(
+            clz = AbstractDungeon.class,
+            method = "returnTrulyRandomColorlessCardInCombat",
+            paramtypez = { Random.class }
+    )
+    public static class AbstractDungeon_returnTrulyRandomColorlessCardInCombat {
+        @SpireInsertPatch(
+                locator = Locator.class,
+                localvars = "list"
+        )
+        @SuppressWarnings("unchecked")
+        public static void patch(Random rng, @ByRef ArrayList[] list) {
+            RemovePersistentPositiveEffects(list[0]);
+        }
+    }
+
+    // Because all of the random card generation functions are structured so similarly, we use the same locator.
+    // Before a card is picked from the list, filter its contents.
+    private static class Locator extends SpireInsertLocator {
+        @Override
+        public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+            final Matcher matcher = new Matcher.MethodCallMatcher(ArrayList.class, "get");
+            return LineFinder.findInOrder(ctMethodToPatch, matcher);
+        }
+    }
+}

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -147,7 +147,7 @@
   },
   "stsjorbsmod:Mending": {
     "NAME": "Mending",
-    "DESCRIPTION": "Gain !M! HP for each stsjorbsmod:Clarity. NL Exhaust."
+    "DESCRIPTION": "Heal !M! HP for each stsjorbsmod:Clarity. NL Exhaust."
   },
   "stsjorbsmod:Rest": {
     "NAME": "Rest",


### PR DESCRIPTION
A number of random card generation methods eliminate cards with
healing effects from the eligible set. We honor the letter and the
spirit of that filtering by tagging our direct healing cards and,
additionally, eliminating cards with a new tag indicating any other
persistent positive effects from being generated as well.

Future cards must be careful to use these tags in order to
indicate when they are not eligible to be generated as a random card.

Resolves #70.

NOTE: I took two stylistic compressions, and I'd like to be sure they seem right to other eyes.
* Patch all of the relevant functions in one file, using inner static classes.
* Use a unified locator for all patches. If a second locator had been needed, I would have given it a more specific name at that point.

NOTE: The colorless card patch isn't necessary at the moment. The more I think about it, the more I think I should remove it.