### PR TITLE
Legendary

### DIFF
--- a/src/main/java/stsjorbsmod/JorbsMod.java
+++ b/src/main/java/stsjorbsmod/JorbsMod.java
@@ -9,8 +9,10 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.evacipated.cardcrawl.mod.stslib.Keyword;
 import com.evacipated.cardcrawl.modthespire.lib.SpireConfig;
+import com.evacipated.cardcrawl.modthespire.lib.SpireEnum;
 import com.evacipated.cardcrawl.modthespire.lib.SpireInitializer;
 import com.google.gson.Gson;
+import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.FontHelper;
 import com.megacrit.cardcrawl.localization.*;
@@ -58,7 +60,19 @@ public class JorbsMod implements
     private static final String MODNAME = "Jorbs Mod";
     private static final String AUTHOR = "Twitch chat"; // And pretty soon - You!
     private static final String DESCRIPTION = "New characters, brought to you by Jorbs and Twitch chat!";
-    
+
+    public static class JorbsCardTags {
+        // Use on a card that brings in a possible beneficial effect that lasts longer than the combat and isn't
+        // directly healing or gaining Max HP. If the effect has indirect healing, such as adding a second effect
+        // that conditionally heals or grants Max HP, do use this card tag instead of HEALING.
+        @SpireEnum(name = "PERSISTENT_POSITIVE_EFFECT")
+        public static AbstractCard.CardTags PERSISTENT_POSITIVE_EFFECT;
+
+        // Use on a card that remembers a memory, which is mechanic specific to the Wanderer character.
+        @SpireEnum(name = "REMEMBER_MEMORY")
+        public static AbstractCard.CardTags REMEMBER_MEMORY;
+    }
+
     // =============== INPUT TEXTURE LOCATION =================
 
     //Mod Badge - A small icon that appears in the mod settings menu next to your mod.

--- a/src/main/java/stsjorbsmod/cards/wanderer/Aid.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Aid.java
@@ -11,7 +11,7 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.KindnessMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class Aid extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(Aid.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/ArcaneForm.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/ArcaneForm.java
@@ -10,8 +10,8 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.*;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.PERSISTENT_POSITIVE_EFFECT;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class ArcaneForm extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(ArcaneForm.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/ColorSpray.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/ColorSpray.java
@@ -16,7 +16,7 @@ import stsjorbsmod.powers.BanishedPower;
 import stsjorbsmod.powers.BurningPower;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class ColorSpray extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(ColorSpray.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/CorpseExplosion_Wanderer.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/CorpseExplosion_Wanderer.java
@@ -15,8 +15,8 @@ import stsjorbsmod.patches.AutoExhumeField;
 import stsjorbsmod.patches.EntombedField;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.PERSISTENT_POSITIVE_EFFECT;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class CorpseExplosion_Wanderer extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(CorpseExplosion_Wanderer.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/Determination.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Determination.java
@@ -11,8 +11,8 @@ import stsjorbsmod.memories.PrideMemory;
 import stsjorbsmod.powers.FragilePower;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.PERSISTENT_POSITIVE_EFFECT;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class Determination extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(Determination.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/DoubleCheck.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/DoubleCheck.java
@@ -12,7 +12,7 @@ import stsjorbsmod.memories.DiligenceMemory;
 import stsjorbsmod.powers.DoubleCheckPower;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class DoubleCheck extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(DoubleCheck.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/EyeOfTheStorm.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/EyeOfTheStorm.java
@@ -10,7 +10,7 @@ import stsjorbsmod.actions.RememberRandomNewMemoryAction;
 import stsjorbsmod.characters.Wanderer;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class EyeOfTheStorm extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(EyeOfTheStorm.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/Feast.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Feast.java
@@ -10,8 +10,8 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.GluttonyMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.PERSISTENT_POSITIVE_EFFECT;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class Feast extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(Feast.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/Fireball.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Fireball.java
@@ -14,7 +14,7 @@ import stsjorbsmod.memories.LustMemory;
 import stsjorbsmod.powers.BurningPower;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 /**
  * Base: Deal 21 damage to all enemies

--- a/src/main/java/stsjorbsmod/cards/wanderer/ForbiddenGrimoire.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/ForbiddenGrimoire.java
@@ -13,6 +13,7 @@ import stsjorbsmod.patches.AutoExhumeField;
 import stsjorbsmod.patches.EntombedField;
 import stsjorbsmod.powers.ForbiddenGrimoireDelayedExhumePower;
 
+import static stsjorbsmod.JorbsMod.JorbsCardTags.LEGENDARY;
 import static stsjorbsmod.JorbsMod.makeCardPath;
 import static stsjorbsmod.patches.MaterialComponentsDeckPatch.MATERIAL_COMPONENT;
 
@@ -36,6 +37,7 @@ public class ForbiddenGrimoire extends CustomJorbsModCard {
         exhaust = true;
 
         upgrade(); // Always starts upgraded
+        tags.add(LEGENDARY);
     }
 
     @Override

--- a/src/main/java/stsjorbsmod/cards/wanderer/FreshAdventure.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/FreshAdventure.java
@@ -12,7 +12,7 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.DiligenceMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 // Deal 12(15) damage and remember Diligence
 public class FreshAdventure extends CustomJorbsModCard {

--- a/src/main/java/stsjorbsmod/cards/wanderer/HedgeWizard.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/HedgeWizard.java
@@ -10,7 +10,7 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.HumilityMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class HedgeWizard extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(HedgeWizard.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/Hibernate.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Hibernate.java
@@ -10,7 +10,7 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.SlothMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class Hibernate extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(Hibernate.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/HoldMonster.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/HoldMonster.java
@@ -14,7 +14,7 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.KindnessMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class HoldMonster extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(HoldMonster.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/LocateObject.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/LocateObject.java
@@ -10,8 +10,8 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.GreedMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.PERSISTENT_POSITIVE_EFFECT;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class LocateObject extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(LocateObject.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/MirrorImage.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/MirrorImage.java
@@ -12,7 +12,7 @@ import stsjorbsmod.memories.KindnessMemory;
 import stsjorbsmod.powers.NextAttackMissesPower;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class MirrorImage extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(MirrorImage.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/OldPocket.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/OldPocket.java
@@ -11,7 +11,7 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.CharityMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class OldPocket extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(OldPocket.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/Rest.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Rest.java
@@ -11,7 +11,7 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.ChastityMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class Rest extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(Rest.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/SmithingStrike.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/SmithingStrike.java
@@ -12,8 +12,8 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.WrathMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.PERSISTENT_POSITIVE_EFFECT;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class SmithingStrike extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(SmithingStrike.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/Stalwart.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Stalwart.java
@@ -10,7 +10,7 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.TemperanceMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class Stalwart extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(Stalwart.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/Thorns.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Thorns.java
@@ -11,7 +11,7 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.HumilityMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class Thorns extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(Thorns.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/TinyHut.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/TinyHut.java
@@ -10,7 +10,7 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.KindnessMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class TinyHut extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(TinyHut.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/UnseenServant.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/UnseenServant.java
@@ -11,7 +11,7 @@ import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.SlothMemory;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class UnseenServant extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(UnseenServant.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/WanderingMind.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/WanderingMind.java
@@ -9,7 +9,7 @@ import stsjorbsmod.actions.RememberRandomNewMemoryAction;
 import stsjorbsmod.characters.Wanderer;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class WanderingMind extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(WanderingMind.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/cards/wanderer/WeightOfMemory.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/WeightOfMemory.java
@@ -12,7 +12,7 @@ import stsjorbsmod.cards.CustomJorbsModCard;
 import stsjorbsmod.characters.Wanderer;
 
 import static stsjorbsmod.JorbsMod.makeCardPath;
-import static stsjorbsmod.characters.Wanderer.Enums.REMEMBER_MEMORY;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 public class WeightOfMemory extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(WeightOfMemory.class.getSimpleName());

--- a/src/main/java/stsjorbsmod/characters/Wanderer.java
+++ b/src/main/java/stsjorbsmod/characters/Wanderer.java
@@ -54,13 +54,6 @@ public class Wanderer extends CustomPlayer {
         public static AbstractCard.CardColor WANDERER_CARD_COLOR;
         @SpireEnum(name = "WANDERER_GRAY_COLOR") @SuppressWarnings("unused")
         public static CardLibrary.LibraryType WANDERER_LIBRARY_COLOR;
-        @SpireEnum(name = "REMEMBER_MEMORY")
-        public static AbstractCard.CardTags REMEMBER_MEMORY;
-        // Use on a card that brings in a possible beneficial effect that lasts longer than the combat and isn't
-        // directly healing or gaining Max HP. If the effect has indirect healing, such as adding a second effect
-        // that conditionally heals or grants Max HP, do use this card tag instead of HEALING.
-        @SpireEnum(name = "PERSISTENT_POSITIVE_EFFECT")
-        public static AbstractCard.CardTags PERSISTENT_POSITIVE_EFFECT;
     }
     
     // Note: These have to live in a separate static subclass to ensure the BaseMode.addColor call can happen before the

--- a/src/main/java/stsjorbsmod/patches/FilterRandomCardGenerationPatch.java
+++ b/src/main/java/stsjorbsmod/patches/FilterRandomCardGenerationPatch.java
@@ -2,17 +2,24 @@ package stsjorbsmod.patches;
 
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.random.Random;
 import javassist.CtBehavior;
 
 import java.util.ArrayList;
 
+import static stsjorbsmod.JorbsMod.JorbsCardTags.LEGENDARY;
 import static stsjorbsmod.JorbsMod.JorbsCardTags.PERSISTENT_POSITIVE_EFFECT;
 
 public class FilterRandomCardGenerationPatch {
     private static void RemovePersistentPositiveEffects(ArrayList<AbstractCard> list) {
         list.removeIf(card -> card.hasTag(PERSISTENT_POSITIVE_EFFECT));
+    }
+
+    private static void RemoveLegendaryCards(ArrayList<AbstractCard> list) {
+        list.removeIf(card -> card.hasTag(LEGENDARY));
     }
 
     @SpirePatch(
@@ -22,7 +29,7 @@ public class FilterRandomCardGenerationPatch {
     )
     public static class AbstractDungeon_returnTrulyRandomCardInCombat_1 {
         @SpireInsertPatch(
-                locator = Locator.class,
+                locator = ArrayList_get_Locator.class,
                 localvars = "list"
         )
         @SuppressWarnings("unchecked")
@@ -38,7 +45,7 @@ public class FilterRandomCardGenerationPatch {
     )
     public static class AbstractDungeon_returnTrulyRandomCardInCombat_2 {
         @SpireInsertPatch(
-                locator = Locator.class,
+                locator = ArrayList_get_Locator.class,
                 localvars = "list"
         )
         @SuppressWarnings("unchecked")
@@ -54,7 +61,7 @@ public class FilterRandomCardGenerationPatch {
     )
     public static class AbstractDungeon_returnTrulyRandomColorlessCardInCombat {
         @SpireInsertPatch(
-                locator = Locator.class,
+                locator = ArrayList_get_Locator.class,
                 localvars = "list"
         )
         @SuppressWarnings("unchecked")
@@ -63,12 +70,39 @@ public class FilterRandomCardGenerationPatch {
         }
     }
 
-    // Because all of the random card generation functions are structured so similarly, we use the same locator.
+    // While we filter Legendary cards from being in the random reward pools after the dungeon initializes, if the
+    // player has the Prismatic Shard relic, this particular method is also used in AbstractDungeon.getRewardCards.
+    @SpirePatch(
+            clz = CardLibrary.class,
+            method = "getAnyColorCard",
+            paramtypez = { AbstractCard.CardRarity.class }
+    )
+    public static class CardLibrary_getAnyColorCard {
+        @SpireInsertPatch(
+                locator = CardGroup_shuffle_Locator.class,
+                localvars = "anyCard"
+        )
+        @SuppressWarnings("unchecked")
+        public static void patch(AbstractCard.CardRarity rarity, CardGroup anyCard) {
+            RemoveLegendaryCards(anyCard.group);
+        }
+    }
+
+    // Because most of the random card generation functions are structured so similarly, we use a shared locator.
     // Before a card is picked from the list, filter its contents.
-    private static class Locator extends SpireInsertLocator {
+    private static class ArrayList_get_Locator extends SpireInsertLocator {
         @Override
         public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
             final Matcher matcher = new Matcher.MethodCallMatcher(ArrayList.class, "get");
+            return LineFinder.findInOrder(ctMethodToPatch, matcher);
+        }
+    }
+
+    // Before the card group is shuffled, filter its contents.
+    private static class CardGroup_shuffle_Locator extends SpireInsertLocator {
+        @Override
+        public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+            final Matcher matcher = new Matcher.MethodCallMatcher(CardGroup.class, "shuffle");
             return LineFinder.findInOrder(ctMethodToPatch, matcher);
         }
     }

--- a/src/main/java/stsjorbsmod/patches/FilterRandomCardGenerationPatch.java
+++ b/src/main/java/stsjorbsmod/patches/FilterRandomCardGenerationPatch.java
@@ -8,7 +8,7 @@ import javassist.CtBehavior;
 
 import java.util.ArrayList;
 
-import static stsjorbsmod.characters.Wanderer.Enums.PERSISTENT_POSITIVE_EFFECT;
+import static stsjorbsmod.JorbsMod.JorbsCardTags.PERSISTENT_POSITIVE_EFFECT;
 
 public class FilterRandomCardGenerationPatch {
     private static void RemovePersistentPositiveEffects(ArrayList<AbstractCard> list) {

--- a/src/main/java/stsjorbsmod/patches/FilterRandomCardGenerationPatch.java
+++ b/src/main/java/stsjorbsmod/patches/FilterRandomCardGenerationPatch.java
@@ -2,24 +2,17 @@ package stsjorbsmod.patches;
 
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.cards.AbstractCard;
-import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
-import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.random.Random;
 import javassist.CtBehavior;
 
 import java.util.ArrayList;
 
-import static stsjorbsmod.JorbsMod.JorbsCardTags.LEGENDARY;
 import static stsjorbsmod.JorbsMod.JorbsCardTags.PERSISTENT_POSITIVE_EFFECT;
 
 public class FilterRandomCardGenerationPatch {
     private static void RemovePersistentPositiveEffects(ArrayList<AbstractCard> list) {
         list.removeIf(card -> card.hasTag(PERSISTENT_POSITIVE_EFFECT));
-    }
-
-    private static void RemoveLegendaryCards(ArrayList<AbstractCard> list) {
-        list.removeIf(card -> card.hasTag(LEGENDARY));
     }
 
     @SpirePatch(
@@ -70,39 +63,12 @@ public class FilterRandomCardGenerationPatch {
         }
     }
 
-    // While we filter Legendary cards from being in the random reward pools after the dungeon initializes, if the
-    // player has the Prismatic Shard relic, this particular method is also used in AbstractDungeon.getRewardCards.
-    @SpirePatch(
-            clz = CardLibrary.class,
-            method = "getAnyColorCard",
-            paramtypez = { AbstractCard.CardRarity.class }
-    )
-    public static class CardLibrary_getAnyColorCard {
-        @SpireInsertPatch(
-                locator = CardGroup_shuffle_Locator.class,
-                localvars = "anyCard"
-        )
-        @SuppressWarnings("unchecked")
-        public static void patch(AbstractCard.CardRarity rarity, CardGroup anyCard) {
-            RemoveLegendaryCards(anyCard.group);
-        }
-    }
-
     // Because most of the random card generation functions are structured so similarly, we use a shared locator.
     // Before a card is picked from the list, filter its contents.
     private static class ArrayList_get_Locator extends SpireInsertLocator {
         @Override
         public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
             final Matcher matcher = new Matcher.MethodCallMatcher(ArrayList.class, "get");
-            return LineFinder.findInOrder(ctMethodToPatch, matcher);
-        }
-    }
-
-    // Before the card group is shuffled, filter its contents.
-    private static class CardGroup_shuffle_Locator extends SpireInsertLocator {
-        @Override
-        public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
-            final Matcher matcher = new Matcher.MethodCallMatcher(CardGroup.class, "shuffle");
             return LineFinder.findInOrder(ctMethodToPatch, matcher);
         }
     }

--- a/src/main/java/stsjorbsmod/patches/LegendaryPatch.java
+++ b/src/main/java/stsjorbsmod/patches/LegendaryPatch.java
@@ -1,0 +1,141 @@
+package stsjorbsmod.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.events.shrines.FountainOfCurseRemoval;
+import com.megacrit.cardcrawl.events.shrines.WeMeetAgain;
+import com.megacrit.cardcrawl.helpers.CardHelper;
+import com.megacrit.cardcrawl.helpers.CardLibrary;
+import com.megacrit.cardcrawl.random.Random;
+import com.megacrit.cardcrawl.relics.Astrolabe;
+import com.megacrit.cardcrawl.relics.DollysMirror;
+import com.megacrit.cardcrawl.relics.EmptyCage;
+import javassist.CtBehavior;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
+import static stsjorbsmod.JorbsMod.JorbsCardTags.LEGENDARY;
+
+public class LegendaryPatch {
+    private static void RemoveLegendaryCards(ArrayList<AbstractCard> list) {
+        list.removeIf(c -> c.hasTag(LEGENDARY));
+    }
+
+    // Legendary cards aren't purgeable. By removing them from choices to purge, we sidestep them even being picked
+    // by the player to remove or transform.
+    @SpirePatch(clz = CardGroup.class, method = "getPurgeableCards")
+    public static class CardGroup_getPurgeableCards {
+        @SpirePostfixPatch
+        public static CardGroup patch(CardGroup result, CardGroup instance) {
+            RemoveLegendaryCards(result.group);
+            return result;
+        }
+    }
+
+    // While we filter Legendary cards from being in the random reward pools after the dungeon initializes, if the
+    // player has the Prismatic Shard relic, this particular method is also used in AbstractDungeon.getRewardCards.
+    // We don't want to modify the overall list of cards that the CardLibrary draws from, hence this patch.
+    @SpirePatch(
+            clz = CardLibrary.class,
+            method = "getAnyColorCard",
+            paramtypez = { AbstractCard.CardRarity.class }
+    )
+    public static class CardLibrary_getAnyColorCard {
+        @SpireInsertPatch(locator = CardGroup_shuffle_Locator.class, localvars = "anyCard")
+        public static void patch(AbstractCard.CardRarity rarity, CardGroup anyCard) {
+            RemoveLegendaryCards(anyCard.group);
+        }
+    }
+
+    // The Falling event removes cards from the deck. It selects them with these methods in CardHelper, and it is
+    // the only consumer of these methods. We effectively replace the whole body be redoing the method's work.
+    @SpirePatch(clz = CardHelper.class, method = "hasCardWithType")
+    public static class CardHelper_hasCardWithType {
+        @SpirePostfixPatch
+        public static boolean patch(AbstractCard.CardType type) {
+            return CardGroup.getGroupWithoutBottledCards(AbstractDungeon.player.masterDeck).group.stream()
+                    .anyMatch(c -> c.type == type && !c.hasTag(LEGENDARY));
+        }
+    }
+
+    @SpirePatch(clz = CardHelper.class, method = "returnCardOfType")
+    public static class CardHelper_returnCardOfType {
+        @SpirePostfixPatch
+        public static AbstractCard patch(AbstractCard.CardType type, Random rng) {
+            ArrayList<AbstractCard> cards =
+                    CardGroup.getGroupWithoutBottledCards(AbstractDungeon.player.masterDeck).group.stream()
+                            .filter(c -> c.type == type && !c.hasTag(LEGENDARY))
+                            .collect(Collectors.toCollection(ArrayList::new));
+            return cards.remove(rng.random(cards.size() - 1));
+        }
+    }
+
+    // The Fountain of Curse Removal event removes curse cards from the deck. It selects them directly from the
+    // masterDeck. We don't let it remove any Legendary curses.
+    //@SpirePatch(clz = FountainOfCurseRemoval.class, method = "buttonEffect")
+    public static class FountainOfCurseRemoval_buttonEffect {
+        // TODO raw patch
+    }
+
+    // The We Meet Again event selects a non-basic, non-curse card. We ensure it's also non-legendary.
+    @SpirePatch(clz = WeMeetAgain.class, method = "getRandomNonBasicCard")
+    public static class WeMeetAgain_getRandomNonBasicCard {
+        @SpireInsertPatch(locator = ArrayList_isEmpty_Locator.class, localvars = "list")
+        public static void patch(ArrayList<AbstractCard> list) {
+            RemoveLegendaryCards(list);
+        }
+    }
+
+    // Astrolabe builds its own list of cards to transform. Filter that list.
+    @SpirePatch(clz = Astrolabe.class, method = "onEquip")
+    public static class Astrolabe_onEquip {
+        @SpireInsertPatch(locator = ArrayList_isEmpty_Locator.class, localvars = "tmp")
+        public static void patch(CardGroup tmp) {
+            RemoveLegendaryCards(tmp.group);
+        }
+    }
+
+    // Dolly's Mirror duplicates a card in the masterDeck. Filter that first.
+    //@SpirePatch(clz = DollysMirror.class, method = "onEquip")
+    public static class DollysMirror_onEquip {
+        // TODO raw patch
+    }
+
+    // Empty Cage optimizes the user's choice, removing all eligible cards if <= 2. Filter that list.
+    @SpirePatch(clz = EmptyCage.class, method = "onEquip")
+    public static class EmptyCage_onEquip {
+        @SpireInsertPatch(locator = ArrayList_isEmpty_Locator.class, localvars = "tmp")
+        public static void patch(CardGroup tmp) {
+            RemoveLegendaryCards(tmp.group);
+        }
+    }
+
+    // ---------- LOCATORS ----------
+
+    private static class ArrayList_add_Locator extends SpireInsertLocator {
+        @Override
+        public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+            final Matcher matcher = new Matcher.MethodCallMatcher(ArrayList.class, "add");
+            return LineFinder.findInOrder(ctMethodToPatch, matcher);
+        }
+    }
+
+    private static class ArrayList_isEmpty_Locator extends SpireInsertLocator {
+        @Override
+        public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+            final Matcher matcher = new Matcher.MethodCallMatcher(ArrayList.class, "isEmpty");
+            return LineFinder.findInOrder(ctMethodToPatch, matcher);
+        }
+    }
+
+    private static class CardGroup_shuffle_Locator extends SpireInsertLocator {
+        @Override
+        public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+            final Matcher matcher = new Matcher.MethodCallMatcher(CardGroup.class, "shuffle");
+            return LineFinder.findInOrder(ctMethodToPatch, matcher);
+        }
+    }
+}


### PR DESCRIPTION
_Notes on the expected final design behaviors from comments in JorbsMod_
Use on a card that can only ever enter the deck by special means, and cannot be removed or transformed once present. The card can exhaust but still counts as present.
Interaction notes:
- Legendary cards will never appear when drafting with the Draft mod enabled. In the implementation as is, CardRewardScreen.draftOpen() calls AbstractDungeon.returnRandomCard() to show three cards. We have filtered the reward pools that returnRandomCard() draws from.
- Legendary rare cards won't be added to the deck with Shiny enabled.  In the implementation as is, the player invokes AbstractDungeon.getEachRare() instead of the CardLibrary's version. This again uses the filtered reward pools, whereas the CardLibrary version would use the full set of available cards.
- Any red, green, or blue cards that duplicate a card could pick a Legendary card. These behaviors remain because this mod is not designed to interact with colored cards from the main game. Known cards: Dual Wield, Nightmare
- Living Wall event: if the player has no purgeable cards, they won't be given a chance to upgrade.
- Designer event: the Remove option can be active without any purgeable cards to select from.

Other notes from the Issue comments:
What's missing?
- validation in *transformCard
- raw patches for DollysMirror and FountainOfCurseRemoval
- validation in onRemoveFromMasterDeck.
Basically, most known situations work, and we're missing logging or extra care for when something unanticipated happens (say, our mod in conjunction with another).