### PR TITLE
Lust applies on-hit, regardless of hitting block, similar to thorns.

### DIFF
--- a/src/main/java/stsjorbsmod/memories/LustMemory.java
+++ b/src/main/java/stsjorbsmod/memories/LustMemory.java
@@ -41,7 +41,7 @@ public class LustMemory extends AbstractMemory {
     public void onAttack(DamageInfo info, int damageAmount, AbstractCreature target) {
         if (isPassiveEffectActive()) {
             // Similar to EnvenomPower
-            if (damageAmount > 0 && target != this.owner && info.type == DamageInfo.DamageType.NORMAL) {
+            if (target != this.owner && info.type == DamageInfo.DamageType.NORMAL) {
                 this.flash();
                 AbstractDungeon.actionManager.addToTop(new ApplyPowerAction(target, this.owner, new BurningPower(target, this.owner, this.PASSIVE_BURNING_ON_ATTACK), this.PASSIVE_BURNING_ON_ATTACK, true));
             }


### PR DESCRIPTION
Gif is using un-updated scorching ray so it hits block for one. Still applies 2 Lust burning.
![LustBurningOnHit](https://user-images.githubusercontent.com/1097069/69506332-2a277d80-0efc-11ea-9620-6ce41c7bb1f9.gif)
