### PR TITLE
20191208 changes

### DIFF
--- a/src/main/java/stsjorbsmod/cards/wanderer/Determination.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Determination.java
@@ -29,6 +29,7 @@ public class Determination extends CustomJorbsModCard {
     public Determination() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
         magicNumber = baseMagicNumber = TURNS_UNTIL_SNAP;
+        exhaust = true;
 
         tags.add(PERSISTENT_POSITIVE_EFFECT);
         tags.add(REMEMBER_MEMORY);

--- a/src/main/java/stsjorbsmod/cards/wanderer/Prepare.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Prepare.java
@@ -30,6 +30,7 @@ public class Prepare extends CustomJorbsModCard {
     public Prepare() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
         magicNumber = baseMagicNumber = COIL;
+        baseBlock = 0;
     }
 
     // Note: because this is dependent on Coil and Coil amount changes during use(), this won't be

--- a/src/main/java/stsjorbsmod/memories/KindnessMemory.java
+++ b/src/main/java/stsjorbsmod/memories/KindnessMemory.java
@@ -27,7 +27,8 @@ public class KindnessMemory extends AbstractMemory {
         this.restoreStrengthActions = new ArrayList<>();
 
         for (AbstractMonster mo : AbstractDungeon.getCurrRoom().monsters.monsters) {
-            AbstractDungeon.actionManager.addToBottom(
+            // add to top for the purposes of hold monster ordering.
+            AbstractDungeon.actionManager.addToTop(
                     new ApplyPowerAction(mo, owner, new StrengthPower(mo, -ENEMY_STRENGTH_REDUCTION), -ENEMY_STRENGTH_REDUCTION, true, AbstractGameAction.AttackEffect.NONE));
 
             if (!mo.hasPower(ArtifactPower.POWER_ID)) {

--- a/src/main/java/stsjorbsmod/powers/BurningPower.java
+++ b/src/main/java/stsjorbsmod/powers/BurningPower.java
@@ -116,7 +116,8 @@ public class BurningPower extends AbstractPower implements CloneablePowerInterfa
 
     @Override
     public int getHealthBarAmount() {
-        return this.amount;
+        int amount = this.amount - owner.currentBlock;
+        return amount < 0 ? 0 : amount;
     }
 
     @Override

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -289,8 +289,8 @@
   },
   "stsjorbsmod:Patron": {
     "NAME": "Patron",
-    "DESCRIPTION": "Ephemeral. NL Exhume when you stsjorbsmod:Snap. NL Deal !D! damage. NL stsjorbsmod:Destroy.",
-    "UPGRADE_DESCRIPTION": "Ephemeral. NL Exhume when you stsjorbsmod:Snap. NL Deal !D! damage. NL stsjorbsmod:Downgrade."
+    "DESCRIPTION": "stsjorbsmod:Ephemeral. NL stsjorbsmod:Exhume when you stsjorbsmod:Snap. NL Deal !D! damage. NL stsjorbsmod:Destroy.",
+    "UPGRADE_DESCRIPTION": "stsjorbsmod:Ephemeral. NL stsjorbsmod:Exhume when you stsjorbsmod:Snap. NL Deal !D! damage. NL stsjorbsmod:Downgrade."
   },
   "stsjorbsmod:Prepare": {
     "NAME": "Prepare",

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -89,8 +89,8 @@
   },
   "stsjorbsmod:Determination": {
     "NAME": "Determination",
-    "DESCRIPTION": "Remember stsjorbsmod:Pride. NL At the end of this turn, stsjorbsmod:Snap.",
-    "UPGRADE_DESCRIPTION": "Remember stsjorbsmod:Pride. NL At the end of your next turn, stsjorbsmod:Snap."
+    "DESCRIPTION": "Remember stsjorbsmod:Pride. NL At the end of this turn, stsjorbsmod:Snap. NL Exhaust.",
+    "UPGRADE_DESCRIPTION": "Remember stsjorbsmod:Pride. NL At the end of your next turn, stsjorbsmod:Snap. NL Exhaust."
   },
   "stsjorbsmod:DisguiseSelf": {
     "NAME": "Disguise Self",


### PR DESCRIPTION
Determination exhausts
Hold Monster str down ordering (now kindness's str down (if not remembered or clarified) then hold monster's str down)
Patron's keywords
Burning renders amount of damage after hitting block
Prepare blocks for exactly coil amount before dex and frail modifiers