### PR TITLE
only snap when the combat is still ongoing

### DIFF
--- a/src/main/java/stsjorbsmod/actions/SnapAction.java
+++ b/src/main/java/stsjorbsmod/actions/SnapAction.java
@@ -7,17 +7,16 @@ import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.DamageAllEnemiesAction;
 import com.megacrit.cardcrawl.actions.common.LoseHPAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
-import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.vfx.BorderFlashEffect;
 import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.MemoryManager;
-import stsjorbsmod.patches.LegendaryPatch;
 import stsjorbsmod.patches.SelfExhumeFields;
 import stsjorbsmod.powers.ExhumeAtStartOfTurnPower;
 import stsjorbsmod.powers.SnappedPower;
+import stsjorbsmod.util.CombatUtils;
 
 
 // At the end of turn 7 deal 5 damage to all enemies and 2 damage to yourself for every clarity bonus you have. You cannot be affected by memories or clarities for the remainder of the fight.
@@ -38,6 +37,10 @@ public class SnapAction extends AbstractGameAction {
 
     public void update() {
         if (target.hasPower(SnappedPower.POWER_ID)) {
+            isDone = true;
+            return;
+        }
+        if (CombatUtils.isCombatBasicallyVictory()) {
             isDone = true;
             return;
         }

--- a/src/main/java/stsjorbsmod/util/CombatUtils.java
+++ b/src/main/java/stsjorbsmod/util/CombatUtils.java
@@ -1,0 +1,20 @@
+package stsjorbsmod.util;
+
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.MinionPower;
+
+public class CombatUtils {
+    /**
+     * If there are any non-minion monsters still alive, then this returns false.
+     * @return returns true if there are no non-minion monsters left alive. Otherwise, returns false.
+     */
+    public static boolean isCombatBasicallyVictory() {
+        for (AbstractMonster m : AbstractDungeon.getMonsters().monsters) {
+            if (!m.hasPower(MinionPower.POWER_ID) && !(m.isDying || m.isDead)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
This should work around the issue where `AbstractMonster::areMonstersBasicallyDead` returns false if minions are still alive.

Other options include to patch `AbstractMonster::areMonstersBasicallyDead` to include minion checks, patch `DamageAction::update` to check minions, create a new DamageAction with a minion check, or Add an action for PurgeMind that removes SnapAction if only minions are left alive.

addresses #269 