### PR TITLE
Implements two Cull changes regarding Legendary cards

### DIFF
--- a/src/main/java/stsjorbsmod/cards/cull/SpiritShield_Cull.java
+++ b/src/main/java/stsjorbsmod/cards/cull/SpiritShield_Cull.java
@@ -8,6 +8,8 @@ import stsjorbsmod.cards.CustomJorbsModCard;
 import stsjorbsmod.characters.Cull;
 import stsjorbsmod.powers.SpiritShieldPower;
 
+import static stsjorbsmod.JorbsMod.JorbsCardTags.LEGENDARY;
+
 public class SpiritShield_Cull extends CustomJorbsModCard {
     public static final String ID = JorbsMod.makeID(SpiritShield_Cull.class);
 
@@ -25,6 +27,8 @@ public class SpiritShield_Cull extends CustomJorbsModCard {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
         magicNumber = baseMagicNumber = DAMAGE_REDUCTION;
         urMagicNumber = baseUrMagicNumber = NUMBER_OF_TURNS;
+
+        tags.add(LEGENDARY);
     }
 
     @Override

--- a/src/main/java/stsjorbsmod/cards/cull/SplinterSoul.java
+++ b/src/main/java/stsjorbsmod/cards/cull/SplinterSoul.java
@@ -37,10 +37,9 @@ public class SplinterSoul extends CustomJorbsModCard {
     public void use(AbstractPlayer p, AbstractMonster m) {
         addToBot(new DamageAction(m, new DamageInfo(p, damage), AttackEffect.SLASH_VERTICAL));
 
-        CardGroup drawPileWithoutLegendary = p.drawPile.getPurgeableCards();
-
-        if (!drawPileWithoutLegendary.isEmpty()) {
-            AbstractCard randomCardInDrawPile = drawPileWithoutLegendary.getRandomCard(AbstractDungeon.cardRandomRng);
+        CardGroup drawPileWithoutUnconsumable = CardGroup.getGroupWithoutBottledCards(p.drawPile.getPurgeableCards());
+        if (!drawPileWithoutUnconsumable.isEmpty()) {
+            AbstractCard randomCardInDrawPile = drawPileWithoutUnconsumable.getRandomCard(AbstractDungeon.cardRandomRng);
             addToBot(new ConsumeCardAction(randomCardInDrawPile));
         }
     }

--- a/src/main/java/stsjorbsmod/cards/cull/SplinterSoul.java
+++ b/src/main/java/stsjorbsmod/cards/cull/SplinterSoul.java
@@ -3,6 +3,7 @@ package stsjorbsmod.cards.cull;
 import com.megacrit.cardcrawl.actions.AbstractGameAction.AttackEffect;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
@@ -36,8 +37,10 @@ public class SplinterSoul extends CustomJorbsModCard {
     public void use(AbstractPlayer p, AbstractMonster m) {
         addToBot(new DamageAction(m, new DamageInfo(p, damage), AttackEffect.SLASH_VERTICAL));
 
-        if (!p.drawPile.isEmpty()) {
-            AbstractCard randomCardInDrawPile = p.drawPile.getRandomCard(AbstractDungeon.cardRandomRng);
+        CardGroup drawPileWithoutLegendary = p.drawPile.getPurgeableCards();
+
+        if (!drawPileWithoutLegendary.isEmpty()) {
+            AbstractCard randomCardInDrawPile = drawPileWithoutLegendary.getRandomCard(AbstractDungeon.cardRandomRng);
             addToBot(new ConsumeCardAction(randomCardInDrawPile));
         }
     }

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -527,7 +527,7 @@
   },
   "stsjorbsmod:SplinterSoul": {
     "NAME": "Splinter Soul",
-    "DESCRIPTION": "Deal !D! damage. NL stsjorbsmod:Consume a random card in your draw pile."
+    "DESCRIPTION": "Deal !D! damage. NL stsjorbsmod:Consume a random non-Legendary card in your draw pile."
   },
   "stsjorbsmod:Stalwart": {
     "NAME": "Stalwart",


### PR DESCRIPTION
- Splinter Soul ignores all Legendary cards in draw pile when finding a Consume target
- Spirit Shield now has Legendary tag