### PR TITLE
Implements Cull potion Ghost Poison

### DIFF
--- a/src/main/java/stsjorbsmod/JorbsMod.java
+++ b/src/main/java/stsjorbsmod/JorbsMod.java
@@ -33,10 +33,7 @@ import stsjorbsmod.console.MemoryCommand;
 import stsjorbsmod.console.PlaySoundCommand;
 import stsjorbsmod.memories.AbstractMemory;
 import stsjorbsmod.memories.MemoryManager;
-import stsjorbsmod.potions.BurningPotion;
-import stsjorbsmod.potions.DimensionDoorPotion;
-import stsjorbsmod.potions.LiquidClarity;
-import stsjorbsmod.potions.LiquidVirtue;
+import stsjorbsmod.potions.*;
 import stsjorbsmod.relics.CustomJorbsModRelic;
 import stsjorbsmod.util.ReflectionUtils;
 import stsjorbsmod.util.TextureLoader;
@@ -310,7 +307,10 @@ public class JorbsMod implements
                 LiquidClarity.POTION_ID, Wanderer.Enums.WANDERER);
         BaseMod.addPotion(LiquidVirtue.class, Color.BLUE, null, Color.PURPLE,
                 LiquidVirtue.POTION_ID, Wanderer.Enums.WANDERER);
-        
+        BaseMod.addPotion(GhostPoisonPotion.class, Color.LIME, Color.BLACK, Color.LIME,
+                GhostPoisonPotion.POTION_ID, Cull.Enums.CULL);
+
+
         // =============== EVENTS =================
         
         // This event will be exclusive to the City (act 2). If you want an event that's present at any

--- a/src/main/java/stsjorbsmod/potions/GhostPoisonPotion.java
+++ b/src/main/java/stsjorbsmod/potions/GhostPoisonPotion.java
@@ -1,0 +1,78 @@
+package stsjorbsmod.potions;
+
+import com.megacrit.cardcrawl.actions.animations.VFXAction;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.PowerTip;
+import com.megacrit.cardcrawl.localization.PotionStrings;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.potions.AbstractPotion;
+import com.megacrit.cardcrawl.powers.BackAttackPower;
+import com.megacrit.cardcrawl.rooms.AbstractRoom;
+import com.megacrit.cardcrawl.vfx.combat.SmokeBombEffect;
+import stsjorbsmod.JorbsMod;
+import stsjorbsmod.actions.IncreaseManifestAction;
+
+public class GhostPoisonPotion extends AbstractPotion {
+    public static final String POTION_ID = JorbsMod.makeID(GhostPoisonPotion.class.getSimpleName());
+    private static final PotionStrings potionStrings = CardCrawlGame.languagePack.getPotionString(POTION_ID);
+    public static final String NAME = potionStrings.NAME;
+    public static final String[] DESCRIPTIONS = potionStrings.DESCRIPTIONS;
+
+    private static final int BASE_POTENCY = 1;
+
+    public GhostPoisonPotion() {
+        super(NAME, POTION_ID, PotionRarity.COMMON, PotionSize.H, PotionColor.SMOKE);
+        this.potency = this.getPotency();
+        this.description = String.format(DESCRIPTIONS[0], this.potency);
+        this.isThrown = true;
+        this.tips.add(new PowerTip(this.name, this.description));
+    }
+
+    @Override
+    public void use(AbstractCreature target) {
+        int liveMonsterCount = 0;
+
+        for (AbstractMonster m : (AbstractDungeon.getCurrRoom()).monsters.monsters) {
+            if (!m.isDeadOrEscaped()) {
+                ++liveMonsterCount;
+                addToBot(new VFXAction(new SmokeBombEffect(m.hb.cX, m.hb.cY)));
+                m.die();
+            }
+        }
+            addToBot(new IncreaseManifestAction(liveMonsterCount));
+
+        if ((AbstractDungeon.getCurrRoom()).phase == AbstractRoom.RoomPhase.COMBAT) {
+            AbstractDungeon.player.hideHealthBar();
+            AbstractDungeon.overlayMenu.endTurnButton.disable();
+        }
+    }
+
+
+    @Override
+    public boolean canUse() {
+        if (super.canUse()) {
+            for (AbstractMonster m : (AbstractDungeon.getCurrRoom()).monsters.monsters) {
+                if (m.hasPower(BackAttackPower.POWER_ID))
+                    return false;
+                if (m.type == AbstractMonster.EnemyType.BOSS || m.type == AbstractMonster.EnemyType.ELITE)
+                    return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+
+
+    @Override
+    public int getPotency(int ascensionLevel) {
+        return BASE_POTENCY;
+    }
+
+    @Override
+    public AbstractPotion makeCopy() {
+        return new GhostPoisonPotion();
+    }
+}

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Potion-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Potion-Strings.json
@@ -11,6 +11,12 @@
       "Ignore paths when choosing the next room to travel to."
     ]
   },
+  "stsjorbsmod:GhostPoisonPotion": {
+    "NAME": "Ghost Poison",
+    "DESCRIPTIONS": [
+      "Gain %1$s #yManifest for each enemy, then win the combat. NL Does not work on Boss and Elite enemies."
+    ]
+  },
   "stsjorbsmod:LiquidClarity": {
     "NAME": "Liquid Clarity",
     "DESCRIPTIONS": [

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Potion-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Potion-Strings.json
@@ -14,7 +14,7 @@
   "stsjorbsmod:GhostPoisonPotion": {
     "NAME": "Ghost Poison",
     "DESCRIPTIONS": [
-      "Gain %1$s #yManifest for each enemy, then win the combat. NL Does not work on Boss and Elite enemies."
+      "Gain #b%1$s #yManifest for each enemy, then win the combat. NL Does not work on Boss and Elite enemies."
     ]
   },
   "stsjorbsmod:LiquidClarity": {


### PR DESCRIPTION
Gain 1 manifest for each enemy in combat, then win the combat if non-elite/non-boss.

- ends combat using m.die() on all monsters notDeadOrEscaping.