### PR TITLE
Burning damage before block drop

### DIFF
--- a/src/main/java/stsjorbsmod/patches/BurningPatch.java
+++ b/src/main/java/stsjorbsmod/patches/BurningPatch.java
@@ -10,11 +10,9 @@ import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.ImageMaster;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
-import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import javassist.CannotCompileException;
 import javassist.expr.ExprEditor;
 import javassist.expr.FieldAccess;
-import stsjorbsmod.JorbsMod;
 import stsjorbsmod.powers.BurningPower;
 import stsjorbsmod.util.ReflectionUtils;
 

--- a/src/main/java/stsjorbsmod/powers/BurningPower.java
+++ b/src/main/java/stsjorbsmod/powers/BurningPower.java
@@ -74,11 +74,11 @@ public class BurningPower extends CustomJorbsModPower implements HealthBarRender
     }
 
     @Override
-    public void atStartOfTurn() {
+    public void onSpecificTrigger() {
         if (AbstractDungeon.getCurrRoom().phase == AbstractRoom.RoomPhase.COMBAT &&
                 !AbstractDungeon.getMonsters().areMonstersBasicallyDead()) {
             this.flashWithoutSound();
-            AbstractDungeon.actionManager.addToBottom(
+            AbstractDungeon.actionManager.addToTop(
                     new BurningLoseHpAction(this.owner, this.source, this.amount, AbstractGameAction.AttackEffect.FIRE));
         }
     }

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Keyword-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Keyword-Strings.json
@@ -1,7 +1,7 @@
 [
   {
     "NAMES": ["burning"],
-    "DESCRIPTION": "Burning creatures take damage at the start of their turn and cannot be healed. Each turn, Burning is reduced by a third."
+    "DESCRIPTION": "Burning creatures take damage at the start of their turn and cannot be healed. Burning damage will hit #yBlock. Each turn, Burning is reduced by a third."
   },
   {
     "NAMES": ["charity"],


### PR DESCRIPTION
Technically at the very end of the player's turn, just before EnemyTurnEffect gets added.
This purposefully renames the file to be a bit more generic.
addresses #321 