### PR TITLE
end of turn memory effects occur before relics, powers, burns, etc.

### DIFF
--- a/src/main/java/stsjorbsmod/patches/MemoryHooksPatch.java
+++ b/src/main/java/stsjorbsmod/patches/MemoryHooksPatch.java
@@ -76,13 +76,13 @@ public class MemoryHooksPatch {
     }
 
     @SpirePatch(
-            clz = AbstractCreature.class,
-            method = "applyEndOfTurnTriggers"
+            clz = GameActionManager.class,
+            method = "callEndOfTurnActions"
     )
-    public static class atEndOfTurnHook {
-        @SpirePostfixPatch
-        public static void patch(AbstractCreature __this) {
-            forEachMemory(__this, m -> m.atEndOfTurn(__this.isPlayer));
+    public static class callEndOfTurnActionsHook {
+        @SpirePrefixPatch
+        public static void patch(GameActionManager __this) {
+            forEachMemory(AbstractDungeon.player, m -> m.atEndOfTurn(AbstractDungeon.player.isPlayer));
         }
     }
 


### PR DESCRIPTION
End of turn memory effects now occur first. This makes Chastity block burns and that curse. I can't think of any particular scenario where this as any unintended side effects.