### PR TITLE
it's not fruit juice

### DIFF
--- a/src/main/java/stsjorbsmod/potions/DimensionDoorPotion.java
+++ b/src/main/java/stsjorbsmod/potions/DimensionDoorPotion.java
@@ -40,7 +40,6 @@ public class DimensionDoorPotion extends FruitJuice {
     public DimensionDoorPotion() {
         super();
         this.ID = POTION_ID;
-        this.name = NAME;
         this.rarity = PotionRarity.RARE;
         this.size = PotionSize.GHOST;
 
@@ -57,6 +56,7 @@ public class DimensionDoorPotion extends FruitJuice {
 
     @Override
     public void initializeData() {
+        this.name = NAME;
         this.potency = this.getPotency();
         this.description = DESCRIPTIONS[0];
         this.tips.clear();


### PR DESCRIPTION
Something in `FruitJuice` base class is overriding the name. This should just force the correct name.