### PR TITLE
rename + add TimeEddyAction in TimeEddyAction

### DIFF
--- a/src/main/java/stsjorbsmod/actions/TimeEddyAction.java
+++ b/src/main/java/stsjorbsmod/actions/TimeEddyAction.java
@@ -1,7 +1,6 @@
 package stsjorbsmod.actions;
 
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
-import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.AbstractPower;
@@ -12,8 +11,8 @@ import stsjorbsmod.powers.CustomJorbsModPower;
 
 import java.util.function.Consumer;
 
-public class TImeEddyAction extends AbstractGameAction {
-    public TImeEddyAction(AbstractCreature target, int turnsToAdvance) {
+public class TimeEddyAction extends AbstractGameAction {
+    public TimeEddyAction(int turnsToAdvance) {
         this.amount = turnsToAdvance;
     }
 
@@ -56,36 +55,39 @@ public class TImeEddyAction extends AbstractGameAction {
 
     @Override
     public void update() {
-        for (int i = 0; i < this.amount; ++i) {
-            // Player turn end
-            forEachApplicablePlayerMemory(m -> m.atEndOfTurn());
-            forEachApplicablePlayerPower(p -> p.atEndOfTurnPreEndTurnCards(true));
-            forEachApplicablePlayerPower(p -> p.atEndOfTurn(true));
+        // Player turn end
+        forEachApplicablePlayerMemory(m -> m.atEndOfTurn());
+        forEachApplicablePlayerPower(p -> p.atEndOfTurnPreEndTurnCards(true));
+        forEachApplicablePlayerPower(p -> p.atEndOfTurn(true));
 
-            // Monster turn start
-            forEachApplicableMonsterPower(p -> { if (p instanceof CustomJorbsModPower) { ((CustomJorbsModPower) p).atStartOfTurnPreLoseBlock(); } });
-            forEachApplicableMonsterPower(p -> p.atStartOfTurn());
-            forEachApplicableMonsterPower(p -> p.atStartOfTurnPostDraw());
+        // Monster turn start
+        forEachApplicableMonsterPower(p -> { if (p instanceof CustomJorbsModPower) { ((CustomJorbsModPower) p).atStartOfTurnPreLoseBlock(); } });
+        forEachApplicableMonsterPower(p -> p.atStartOfTurn());
+        forEachApplicableMonsterPower(p -> p.atStartOfTurnPostDraw());
 
-            // Monster turn
-            forEachApplicableMonsterPower(p -> p.duringTurn());
+        // Monster turn
+        forEachApplicableMonsterPower(p -> p.duringTurn());
 
-            // Monster turn end
-            forEachApplicableMonsterPower(p -> { if (p instanceof BurningPower) { p.onSpecificTrigger(); } });
-            forEachApplicableMonsterPower(p -> p.atEndOfTurnPreEndTurnCards(false));
-            forEachApplicableMonsterPower(p -> p.atEndOfTurn(false));
+        // Monster turn end
+        forEachApplicableMonsterPower(p -> { if (p instanceof BurningPower) { p.onSpecificTrigger(); } });
+        forEachApplicableMonsterPower(p -> p.atEndOfTurnPreEndTurnCards(false));
+        forEachApplicableMonsterPower(p -> p.atEndOfTurn(false));
 
-            // Round end
-            forEachApplicablePlayerPower(p -> p.atEndOfRound());
-            forEachApplicableMonsterPower(p -> p.atEndOfRound());
+        // Round end
+        forEachApplicablePlayerPower(p -> p.atEndOfRound());
+        forEachApplicableMonsterPower(p -> p.atEndOfRound());
 
-            // Player turn start
-            forEachApplicablePlayerPower(p -> p.atStartOfTurn());
-            forEachApplicablePlayerMemory(m -> m.atStartOfTurnPostDraw());
-            forEachApplicablePlayerPower(p -> p.atStartOfTurnPostDraw());
+        // Player turn start
+        forEachApplicablePlayerPower(p -> p.atStartOfTurn());
+        forEachApplicablePlayerMemory(m -> m.atStartOfTurnPostDraw());
+        forEachApplicablePlayerPower(p -> p.atStartOfTurnPostDraw());
 
-            // Player turn
-            forEachApplicablePlayerPower(p -> p.duringTurn());
+        // Player turn
+        forEachApplicablePlayerPower(p -> p.duringTurn());
+
+        // base case, don't accidentally end up Time Eddying forever
+        if (amount > 1) {
+            addToBot(new TimeEddyAction(amount - 1));
         }
 
         isDone = true;

--- a/src/main/java/stsjorbsmod/cards/wanderer/materialcomponents/TimeEddy.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/materialcomponents/TimeEddy.java
@@ -3,8 +3,7 @@ package stsjorbsmod.cards.wanderer.materialcomponents;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import stsjorbsmod.JorbsMod;
-import stsjorbsmod.actions.TImeEddyAction;
-import stsjorbsmod.cards.CustomJorbsModCard;
+import stsjorbsmod.actions.TimeEddyAction;
 import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.patches.EphemeralField;
 
@@ -29,7 +28,7 @@ public class TimeEddy extends MaterialComponent {
 
     @Override
     public void useMaterialComponent(AbstractPlayer p, AbstractMonster m) {
-        addToBot(new TImeEddyAction(p, magicNumber));
+        addToBot(new TimeEddyAction(magicNumber));
     }
 
     @Override


### PR DESCRIPTION
`TImeEddyAction` bugged me. renamed it.
`TimeEddyAction` adds itself at the end of `TimeEddyAction::update`. Assumes actions with bad interactions won't add other actions before `TimeEddyAction` goes again. 
https://youtu.be/F6tdXINTcCs
Addresses #334 end of turn dex down