### PR TITLE
Bottle relics onEquip

### DIFF
--- a/src/main/java/stsjorbsmod/patches/BottledMemoryPatch.java
+++ b/src/main/java/stsjorbsmod/patches/BottledMemoryPatch.java
@@ -6,15 +6,11 @@ import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.events.shrines.Duplicator;
 import com.megacrit.cardcrawl.events.shrines.FountainOfCurseRemoval;
-import com.megacrit.cardcrawl.relics.BottledFlame;
-import com.megacrit.cardcrawl.relics.BottledLightning;
-import com.megacrit.cardcrawl.relics.BottledTornado;
 import com.megacrit.cardcrawl.relics.DollysMirror;
 import javassist.CannotCompileException;
 import javassist.CtBehavior;
 import javassist.expr.ExprEditor;
 import javassist.expr.FieldAccess;
-import javassist.expr.MethodCall;
 import stsjorbsmod.relics.BottledMemoryRelic;
 
 public class BottledMemoryPatch {
@@ -29,47 +25,6 @@ public class BottledMemoryPatch {
         public static AbstractCard patch(AbstractCard __return, AbstractCard __this) {
             AbstractCardMemoryFields.inBottleMemory.set(__return, AbstractCardMemoryFields.inBottleMemory.get(__this));
             return __return;
-        }
-    }
-
-    public static class BottledGetCardsExprEditor extends ExprEditor {
-        private String methodName;
-
-        BottledGetCardsExprEditor(String methodName) {
-            this.methodName = methodName;
-        }
-
-        @Override
-        public void edit(MethodCall methodCall) throws CannotCompileException {
-            if (methodCall.getClassName().equals(CardGroup.class.getName()) && methodCall.getMethodName().equals(methodName)) {
-                methodCall.replace("{ $_ = (stsjorbsmod.patches.BottledMemoryPatch.removeBottledCards($proceed())); }");
-            }
-        }
-    }
-
-    public static CardGroup removeBottledCards(CardGroup cards) {
-        cards.group.removeIf(c -> c.inBottleTornado || c.inBottleFlame || c.inBottleLightning || AbstractCardMemoryFields.inBottleMemory.get(c));
-        return cards;
-    }
-
-    @SpirePatch(clz = BottledTornado.class, method = "onEquip")
-    public static class BottledTornado_onEquip {
-        public static ExprEditor Instrument() {
-            return new BottledGetCardsExprEditor("getPowers");
-        }
-    }
-
-    @SpirePatch(clz = BottledFlame.class, method = "onEquip")
-    public static class BottledFlame_onEquip {
-        public static ExprEditor Instrument() {
-            return new BottledGetCardsExprEditor("getAttacks");
-        }
-    }
-
-    @SpirePatch(clz = BottledLightning.class, method = "onEquip")
-    public static class BottledLightning_onEquip {
-        public static ExprEditor Instrument() {
-            return new BottledGetCardsExprEditor("getSkills");
         }
     }
 

--- a/src/main/java/stsjorbsmod/patches/BottledRelic_onEquipPatch.java
+++ b/src/main/java/stsjorbsmod/patches/BottledRelic_onEquipPatch.java
@@ -1,0 +1,58 @@
+package stsjorbsmod.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.relics.BottledFlame;
+import com.megacrit.cardcrawl.relics.BottledLightning;
+import com.megacrit.cardcrawl.relics.BottledTornado;
+import javassist.CannotCompileException;
+import javassist.expr.ExprEditor;
+import javassist.expr.MethodCall;
+
+import java.util.ArrayList;
+
+import static stsjorbsmod.JorbsMod.JorbsCardTags.LEGENDARY;
+import static stsjorbsmod.patches.EntombedPatch.isEntombed;
+
+@SpirePatch(clz = BottledFlame.class, method = "onEquip")
+@SpirePatch(clz = BottledLightning.class, method = "onEquip")
+@SpirePatch(clz = BottledTornado.class, method = "onEquip")
+public class BottledRelic_onEquipPatch {
+    /**
+     * Returns all the bottleable cards in the parameter CardGroup. Since CardGroup::getPurgeableCards is patched to
+     * never return Legendary cards, we add them back into this CardGroup because they can be bottled.
+     *
+     * @param purgeableCards Likely the result of masterdeck.getPurgeableCards
+     * @return all bottleable cards from the CardGroup passed in.
+     */
+    public static CardGroup getCardsForBottling(CardGroup purgeableCards) {
+        ArrayList<AbstractCard> originalCardList = new ArrayList<>(purgeableCards.group);
+        for (AbstractCard c : AbstractDungeon.player.masterDeck.group) {
+            if (c.hasTag(LEGENDARY)) {
+                originalCardList.add(c);
+            }
+        }
+        CardGroup result = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
+        for (AbstractCard c : purgeableCards.group) {
+            if (!isEntombed(c)) {
+                result.group.add(c);
+            }
+        }
+        return result;
+    }
+
+    public static class GetBottleableCardsExprEditor extends ExprEditor {
+        @Override
+        public void edit(MethodCall methodCall) throws CannotCompileException {
+            if (methodCall.getClassName().equals(CardGroup.class.getName()) && methodCall.getMethodName().equals("getPurgeableCards")) {
+                methodCall.replace(String.format("{ $_ = %1$s.getCardsForBottling($proceed($$)); }", BottledRelic_onEquipPatch.class.getName()));
+            }
+        }
+    }
+
+    public static ExprEditor Instrument() {
+        return new GetBottleableCardsExprEditor();
+    }
+}

--- a/src/main/java/stsjorbsmod/patches/BottledRelic_onEquipPatch.java
+++ b/src/main/java/stsjorbsmod/patches/BottledRelic_onEquipPatch.java
@@ -1,53 +1,25 @@
 package stsjorbsmod.patches;
 
 import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
-import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.CardGroup;
-import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.relics.BottledFlame;
 import com.megacrit.cardcrawl.relics.BottledLightning;
 import com.megacrit.cardcrawl.relics.BottledTornado;
 import javassist.CannotCompileException;
 import javassist.expr.ExprEditor;
 import javassist.expr.MethodCall;
-
-import java.util.ArrayList;
-
-import static stsjorbsmod.JorbsMod.JorbsCardTags.LEGENDARY;
-import static stsjorbsmod.patches.EntombedPatch.isEntombed;
+import stsjorbsmod.util.CardUtils;
 
 @SpirePatch(clz = BottledFlame.class, method = "onEquip")
 @SpirePatch(clz = BottledLightning.class, method = "onEquip")
 @SpirePatch(clz = BottledTornado.class, method = "onEquip")
 public class BottledRelic_onEquipPatch {
-    /**
-     * Returns all the bottleable cards in the parameter CardGroup. Since CardGroup::getPurgeableCards is patched to
-     * never return Legendary cards, we add them back into this CardGroup because they can be bottled.
-     *
-     * @param purgeableCards Likely the result of masterdeck.getPurgeableCards
-     * @return all bottleable cards from the CardGroup passed in.
-     */
-    public static CardGroup getCardsForBottling(CardGroup purgeableCards) {
-        ArrayList<AbstractCard> originalCardList = new ArrayList<>(purgeableCards.group);
-        for (AbstractCard c : AbstractDungeon.player.masterDeck.group) {
-            if (c.hasTag(LEGENDARY)) {
-                originalCardList.add(c);
-            }
-        }
-        CardGroup result = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
-        for (AbstractCard c : purgeableCards.group) {
-            if (!isEntombed(c)) {
-                result.group.add(c);
-            }
-        }
-        return result;
-    }
 
     public static class GetBottleableCardsExprEditor extends ExprEditor {
         @Override
         public void edit(MethodCall methodCall) throws CannotCompileException {
             if (methodCall.getClassName().equals(CardGroup.class.getName()) && methodCall.getMethodName().equals("getPurgeableCards")) {
-                methodCall.replace(String.format("{ $_ = %1$s.getCardsForBottling($proceed($$)); }", BottledRelic_onEquipPatch.class.getName()));
+                methodCall.replace(String.format("{ $_ = %1$s.getCardsForBottling($proceed($$)); }", CardUtils.class.getName()));
             }
         }
     }

--- a/src/main/java/stsjorbsmod/patches/EntombedPatch.java
+++ b/src/main/java/stsjorbsmod/patches/EntombedPatch.java
@@ -17,24 +17,6 @@ public class EntombedPatch {
     public static boolean isEntombed(AbstractCard card) {
         return EntombedField.entombed.get(card);
     }
-    public static CardGroup filterOutEntombedCards(CardGroup cards) {
-        CardGroup retVal = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
-        for (AbstractCard card : cards.group) {
-            if (!isEntombed(card)) {
-                retVal.group.add(card);
-            }
-        }
-        return retVal;
-    }
-
-    public static class TreatEntombedAsNonPurgableExprEditor extends ExprEditor {
-        @Override
-        public void edit(MethodCall methodCall) throws CannotCompileException {
-            if (methodCall.getClassName().equals(CardGroup.class.getName()) && methodCall.getMethodName().equals("getPurgeableCards")) {
-                methodCall.replace(String.format("{ $_ = %1$s.filterOutEntombedCards($proceed($$)); }", EntombedPatch.class.getName()));
-            }
-        }
-    }
 
     // Remove Entombed cards from draw pile
     @SpirePatch(
@@ -78,14 +60,6 @@ public class EntombedPatch {
                 return LineFinder.findInOrder(ctBehavior, finalMatcher);
             }
         }
-    }
-
-    // Prevent Entombed cards from being bottled
-    @SpirePatch(clz = BottledFlame.class, method = "onEquip")
-    @SpirePatch(clz = BottledLightning.class, method = "onEquip")
-    @SpirePatch(clz = BottledTornado.class, method = "onEquip")
-    public static class BottledFlame_onEquip {
-        public static ExprEditor Instrument() { return new TreatEntombedAsNonPurgableExprEditor(); };
     }
 }
 

--- a/src/main/java/stsjorbsmod/patches/LegendaryPatch.java
+++ b/src/main/java/stsjorbsmod/patches/LegendaryPatch.java
@@ -157,35 +157,6 @@ public class LegendaryPatch {
         }
     }
 
-    // This should act like the original, unpatched version of CardGroup::getPurgeableCards
-    public static CardGroup getPurgeableOrLegendaryCards(CardGroup originalCards) {
-        CardGroup result = originalCards.getPurgeableCards(); // without legendaries
-        for (AbstractCard c : originalCards.group) {
-            if (c.hasTag(LEGENDARY)) {
-                result.group.add(c);
-            }
-        }
-        return result;
-    }
-
-    // Bottle relics are exceptional in that they use getPurgeableCards to determine candidates but we don't want to
-    // exclude Legendary cards from them
-    @SpirePatch(clz = BottledFlame.class, method = "onEquip")
-    @SpirePatch(clz = BottledLightning.class, method = "onEquip")
-    @SpirePatch(clz = BottledTornado.class, method = "onEquip")
-    public static class BottledRelic_onEquip {
-        public static ExprEditor Instrument() {
-            return new ExprEditor() {
-                @Override
-                public void edit(MethodCall m) throws CannotCompileException {
-                    if (m.getClassName().equals(CardGroup.class.getName()) && m.getMethodName().equals("getPurgeableCards")) {
-                        m.replace(String.format("{ $_ = %1$s.getPurgeableOrLegendaryCards($0); }", LegendaryPatch.class.getName()));
-                    }
-                }
-            };
-        }
-    }
-
     // Legendary cards aren't purgeable. By removing them from choices to purge, we sidestep them even being picked
     // by the player to remove or transform.
     @SpirePatch(clz = CardGroup.class, method = "getPurgeableCards")

--- a/src/main/java/stsjorbsmod/relics/BottledMemoryRelic.java
+++ b/src/main/java/stsjorbsmod/relics/BottledMemoryRelic.java
@@ -1,23 +1,17 @@
 package stsjorbsmod.relics;
 
-import basemod.BaseMod;
 import basemod.abstracts.CustomBottleRelic;
 import basemod.abstracts.CustomSavable;
-import com.evacipated.cardcrawl.mod.stslib.actions.common.AutoplayCardAction;
-import com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.AutoplayField;
 import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
-import com.megacrit.cardcrawl.actions.utility.UseCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.FontHelper;
 import com.megacrit.cardcrawl.helpers.PowerTip;
 import com.megacrit.cardcrawl.localization.LocalizedStrings;
-import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
-import stsjorbsmod.patches.BottledMemoryPatch;
+import stsjorbsmod.util.CardUtils;
 
-import java.util.Iterator;
 import java.util.function.Predicate;
 
 import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
@@ -64,7 +58,8 @@ public class BottledMemoryRelic extends CustomJorbsModRelic implements CustomBot
 
     @Override
     public void onEquip() {
-        CardGroup rememberCards = CardGroup.getGroupWithoutBottledCards(AbstractDungeon.player.masterDeck.getPurgeableCards());
+        // follow same behavior as base game bottle relics. Maybe there's some mod that adds a bottle mechanic changing card using getPurgeableCards
+        CardGroup rememberCards = CardUtils.getCardsForBottling(AbstractDungeon.player.masterDeck.getPurgeableCards());
         rememberCards.group.removeIf(c -> !c.hasTag(REMEMBER_MEMORY));
         if (rememberCards.size() > 0) {
             this.cardSelected = false;

--- a/src/main/java/stsjorbsmod/util/CardUtils.java
+++ b/src/main/java/stsjorbsmod/util/CardUtils.java
@@ -1,0 +1,47 @@
+package stsjorbsmod.util;
+
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import stsjorbsmod.patches.BottledMemoryPatch;
+
+import java.util.ArrayList;
+
+import static stsjorbsmod.JorbsMod.JorbsCardTags.LEGENDARY;
+import static stsjorbsmod.patches.EntombedPatch.isEntombed;
+
+public class CardUtils {
+    /**
+     * Returns all the bottleable cards in the parameter CardGroup. Since CardGroup::getPurgeableCards is patched to
+     * never return Legendary cards, we add them back into this CardGroup because they can be bottled.
+     *
+     * @param purgeableCards Likely the result of masterdeck.getPurgeableCards
+     * @return all bottleable cards from the CardGroup passed in.
+     */
+    public static CardGroup getCardsForBottling(CardGroup purgeableCards) {
+        ArrayList<AbstractCard> originalCardList = new ArrayList<>(purgeableCards.group);
+        for (AbstractCard c : AbstractDungeon.player.masterDeck.group) {
+            if (c.hasTag(LEGENDARY)) {
+                originalCardList.add(c);
+            }
+        }
+        CardGroup result = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
+        for (AbstractCard c : originalCardList) {
+            // removes entombed and bottled cards from the CardGroup
+            if (CardUtils.isBottleable(c)) {
+                result.group.add(c);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * A card is considered bottleable if it is not entombed and not already bottled
+     *
+     * @param c AbstractCard to check
+     * @return true if the card is bottleable, false otherwise
+     */
+    public static boolean isBottleable(AbstractCard c) {
+        return !isEntombed(c) && !c.inBottleTornado && !c.inBottleFlame && !c.inBottleLightning && !BottledMemoryPatch.AbstractCardMemoryFields.inBottleMemory.get(c);
+    }
+}


### PR DESCRIPTION
- Fixes Bottled Memory being able to select entombed cards... whoops
- Fixes occasionally being able to bottle Entombed cards with base game bottle relics
- Merges Legendary, Entombed, and BottledMemory patches into a single `BottleRelics_onEquipPatch`
- Refactors bottleability into a single method