### PR TITLE
Strange Pendant resets at the start of turn now

### DIFF
--- a/src/main/java/stsjorbsmod/powers/StrangePendantPower.java
+++ b/src/main/java/stsjorbsmod/powers/StrangePendantPower.java
@@ -23,7 +23,7 @@ public class StrangePendantPower extends CustomJorbsModPower implements OnPlayer
     }
 
     @Override
-    public void atEndOfTurn(boolean isPlayer) {
+    public void atStartOfTurn() {
         this.damageAbsorbedThisTurn = 0;
     }
 


### PR DESCRIPTION
addresses #401 
it's not exactly directly addressing it, but the interaction between the two are fine, just a matter of it being non-intuitive when the reset occurs