### PR TITLE
Balance 20200215

### DIFF
--- a/src/main/java/stsjorbsmod/cards/wanderer/BookOfTongues.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/BookOfTongues.java
@@ -26,13 +26,14 @@ public class BookOfTongues extends CustomJorbsModCard {
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-        addToBot(new ApplyPowerAction(p, p, new BookOfTonguesPower(p, this.magicNumber, this.upgraded)));
+        addToBot(new ApplyPowerAction(p, p, new BookOfTonguesPower(p, this.magicNumber)));
     }
 
     @Override
     public void upgrade() {
         if (!upgraded) {
             upgradeName();
+            isInnate = true;
             upgradeDescription();
         }
     }

--- a/src/main/java/stsjorbsmod/cards/wanderer/BurningFlask.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/BurningFlask.java
@@ -17,7 +17,7 @@ public class BurningFlask extends CustomJorbsModCard {
     public static final CardColor COLOR = Wanderer.Enums.WANDERER_CARD_COLOR;
 
     private static final int COST = 1;
-    private static final int BURNING = 8;
+    private static final int BURNING = 7;
     private static final int BURNING_PLUS_UPGRADE = 3;
 
     public BurningFlask() {

--- a/src/main/java/stsjorbsmod/cards/wanderer/ChatteringStrike.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/ChatteringStrike.java
@@ -20,8 +20,9 @@ public class ChatteringStrike extends CustomJorbsModCard {
 
     private static final int COST = 1;
     private static final int DAMAGE = 5;
-    private static final int UPGRADE_PLUS_DAMAGE = 2;
+    private static final int UPGRADE_PLUS_DAMAGE = -1;
     private static final int ADDITIONAL_PLAYS = 1;
+    private static final int UPGRADE_PLUS_ADDITIONAL_PLAYS = 1;
 
     public ChatteringStrike() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
@@ -48,6 +49,7 @@ public class ChatteringStrike extends CustomJorbsModCard {
         if (!upgraded) {
             upgradeName();
             upgradeDamage(UPGRADE_PLUS_DAMAGE);
+            upgradeMagicNumber(UPGRADE_PLUS_ADDITIONAL_PLAYS);
             upgradeDescription();
         }
     }

--- a/src/main/java/stsjorbsmod/cards/wanderer/DeathThroes.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/DeathThroes.java
@@ -6,6 +6,7 @@ import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import stsjorbsmod.JorbsMod;
+import stsjorbsmod.actions.GainSpecificClarityAction;
 import stsjorbsmod.cards.CustomJorbsModCard;
 import stsjorbsmod.actions.RememberSpecificMemoryAction;
 import stsjorbsmod.characters.Wanderer;
@@ -27,7 +28,6 @@ public class DeathThroes extends CustomJorbsModCard {
 
     private static final int COST = 0;
     private static final int DAMAGE = 14;
-    private static final int UPGRADE_PLUS_DAMAGE = 4;
 
     public DeathThroes() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
@@ -43,14 +43,18 @@ public class DeathThroes extends CustomJorbsModCard {
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
         addToBot(new DamageAction(m, new DamageInfo(p, damage), AttackEffect.FIRE));
-        addToBot(new RememberSpecificMemoryAction(p, WrathMemory.STATIC.ID));
+        if (upgraded) {
+            addToBot(new GainSpecificClarityAction(p, WrathMemory.STATIC.ID));
+        } else {
+            addToBot(new RememberSpecificMemoryAction(p, WrathMemory.STATIC.ID));
+        }
     }
 
     @Override
     public void upgrade() {
         if (!upgraded) {
             upgradeName();
-            upgradeDamage(UPGRADE_PLUS_DAMAGE);
+            tags.remove(REMEMBER_MEMORY);
             upgradeDescription();
         }
     }

--- a/src/main/java/stsjorbsmod/cards/wanderer/FlameWard.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/FlameWard.java
@@ -24,9 +24,9 @@ public class FlameWard extends CustomJorbsModCard {
     public static final CardColor COLOR = Wanderer.Enums.WANDERER_CARD_COLOR;
 
     private static final int COST = 2;
-    private static final int BLOCK = 11;
+    private static final int BLOCK = 10;
     private static final int UPGRADE_PLUS_BLOCK = 2;
-    private static final int BURNING = 11;
+    private static final int BURNING = 10;
     private static final int UPGRADE_PLUS_BURNING = 2;
 
     public FlameWard() {

--- a/src/main/java/stsjorbsmod/cards/wanderer/FreshAdventure.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/FreshAdventure.java
@@ -26,7 +26,7 @@ public class FreshAdventure extends CustomJorbsModCard implements OnModifyMemori
     public static final CardColor COLOR = Wanderer.Enums.WANDERER_CARD_COLOR;
 
     private static final int COST = 2;
-    private static final int DAMAGE = 14;
+    private static final int DAMAGE = 13;
     private static final int UPGRADE_PLUS_DMG = 3;
     private static final int WRATH_STACK_ON_SNAP = 1;
 

--- a/src/main/java/stsjorbsmod/cards/wanderer/FreshAdventure.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/FreshAdventure.java
@@ -6,15 +6,18 @@ import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import stsjorbsmod.JorbsMod;
+import stsjorbsmod.actions.ConsumerGameAction;
 import stsjorbsmod.cards.CustomJorbsModCard;
 import stsjorbsmod.actions.RememberSpecificMemoryAction;
 import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.DiligenceMemory;
+import stsjorbsmod.memories.OnModifyMemoriesSubscriber;
+import stsjorbsmod.memories.WrathMemory;
 
 import static stsjorbsmod.JorbsMod.JorbsCardTags.REMEMBER_MEMORY;
 
 // Deal 12(15) damage and remember Diligence
-public class FreshAdventure extends CustomJorbsModCard {
+public class FreshAdventure extends CustomJorbsModCard implements OnModifyMemoriesSubscriber {
     public static final String ID = JorbsMod.makeID(FreshAdventure.class);
 
     private static final CardRarity RARITY = CardRarity.BASIC;
@@ -25,10 +28,12 @@ public class FreshAdventure extends CustomJorbsModCard {
     private static final int COST = 2;
     private static final int DAMAGE = 14;
     private static final int UPGRADE_PLUS_DMG = 3;
+    private static final int WRATH_STACK_ON_SNAP = 1;
 
     public FreshAdventure() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
         baseDamage = DAMAGE;
+        magicNumber = baseMagicNumber = WRATH_STACK_ON_SNAP;
 
         this.tags.add(REMEMBER_MEMORY);
     }
@@ -37,6 +42,11 @@ public class FreshAdventure extends CustomJorbsModCard {
     public void use(AbstractPlayer p, AbstractMonster m) {
         addToBot(new DamageAction(m, new DamageInfo(p, damage), AttackEffect.SLASH_DIAGONAL));
         addToBot(new RememberSpecificMemoryAction(p, DiligenceMemory.STATIC.ID));
+    }
+
+    @Override
+    public void onSnap() {
+        addToBot(new ConsumerGameAction<>(WrathMemory::permanentlyIncreaseCardDamage, this));
     }
 
     @Override

--- a/src/main/java/stsjorbsmod/cards/wanderer/GatherPower.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/GatherPower.java
@@ -18,7 +18,7 @@ public class GatherPower extends CustomJorbsModCard {
     public static final CardColor COLOR = Wanderer.Enums.WANDERER_CARD_COLOR;
 
     private static final int COST = 1;
-    private static final int DRAW = 2;
+    private static final int DRAW = 1;
     private static final int NEXT_ATTACK_ADDITIONAL_TIMES = 1;
     private static final int UPGRADE_PLUS_NEXT_ATTACK_ADDITIONAL_TIMES = 1;
 

--- a/src/main/java/stsjorbsmod/cards/wanderer/Hibernate.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Hibernate.java
@@ -20,7 +20,7 @@ public class Hibernate extends CustomJorbsModCard {
     public static final CardColor COLOR = Wanderer.Enums.WANDERER_CARD_COLOR;
 
     private static final int COST = 2;
-    private static final int BLOCK = 16;
+    private static final int BLOCK = 15;
     private static final int UPGRADE_PLUS_BLOCK = 4;
 
     public Hibernate() {

--- a/src/main/java/stsjorbsmod/cards/wanderer/Hurt.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Hurt.java
@@ -7,7 +7,6 @@ import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import stsjorbsmod.JorbsMod;
-import stsjorbsmod.actions.GainClarityOfCurrentMemoryAction;
 import stsjorbsmod.cards.CustomJorbsModCard;
 import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.MemoryManager;
@@ -22,6 +21,7 @@ public class Hurt extends CustomJorbsModCard {
 
     private static final int COST = 1;
     private static final int DAMAGE = 12;
+    private static final int UPGRADE_PLUS_DMG = 4;
     private static final int HP_LOSS_PER_CLARITY = 1;
 
     public Hurt() {
@@ -43,9 +43,6 @@ public class Hurt extends CustomJorbsModCard {
         if (magicNumber > 0) {
             addToBot(new DamageAction(p, new DamageInfo(p, magicNumber, DamageInfo.DamageType.HP_LOSS), AttackEffect.SHIELD));
         }
-        if (upgraded) {
-            addToBot(new GainClarityOfCurrentMemoryAction(p));
-        }
     }
 
     @Override
@@ -57,6 +54,7 @@ public class Hurt extends CustomJorbsModCard {
     public void upgrade() {
         if (!upgraded) {
             upgradeName();
+            upgradeDamage(UPGRADE_PLUS_DMG);
             upgradeDescription();
         }
     }

--- a/src/main/java/stsjorbsmod/cards/wanderer/Hurt.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Hurt.java
@@ -7,6 +7,7 @@ import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import stsjorbsmod.JorbsMod;
+import stsjorbsmod.actions.GainClarityOfCurrentMemoryAction;
 import stsjorbsmod.cards.CustomJorbsModCard;
 import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.memories.MemoryManager;
@@ -21,7 +22,6 @@ public class Hurt extends CustomJorbsModCard {
 
     private static final int COST = 1;
     private static final int DAMAGE = 12;
-    private static final int UPGRADE_PLUS_DMG = 4;
     private static final int HP_LOSS_PER_CLARITY = 1;
 
     public Hurt() {
@@ -43,6 +43,9 @@ public class Hurt extends CustomJorbsModCard {
         if (magicNumber > 0) {
             addToBot(new DamageAction(p, new DamageInfo(p, magicNumber, DamageInfo.DamageType.HP_LOSS), AttackEffect.SHIELD));
         }
+        if (upgraded) {
+            addToBot(new GainClarityOfCurrentMemoryAction(p));
+        }
     }
 
     @Override
@@ -54,7 +57,6 @@ public class Hurt extends CustomJorbsModCard {
     public void upgrade() {
         if (!upgraded) {
             upgradeName();
-            upgradeDamage(UPGRADE_PLUS_DMG);
             upgradeDescription();
         }
     }

--- a/src/main/java/stsjorbsmod/cards/wanderer/Materialize.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Materialize.java
@@ -17,8 +17,8 @@ public class Materialize extends CustomJorbsModCard {
     private static final CardType TYPE = CardType.SKILL;
     public static final CardColor COLOR = Wanderer.Enums.WANDERER_CARD_COLOR;
 
-    private static final int COST = 0;
-    private static final int BLOCK = 4;
+    private static final int COST = 1;
+    private static final int BLOCK = 5;
     private static final int UPGRADE_PLUS_BLOCK = 2;
 
     public Materialize() {

--- a/src/main/java/stsjorbsmod/cards/wanderer/Rediscovery.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Rediscovery.java
@@ -17,7 +17,7 @@ public class Rediscovery extends CustomJorbsModCard {
     private static final CardType TYPE = CardType.POWER;
     public static final CardColor COLOR = Wanderer.Enums.WANDERER_CARD_COLOR;
 
-    private static final int COST = 0;
+    private static final int COST = 1;
 
     public Rediscovery() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);

--- a/src/main/java/stsjorbsmod/cards/wanderer/Rest.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Rest.java
@@ -21,7 +21,7 @@ public class Rest extends CustomJorbsModCard {
     public static final CardColor COLOR = Wanderer.Enums.WANDERER_CARD_COLOR;
 
     private static final int COST = 2;
-    private static final int BLOCK = 10;
+    private static final int BLOCK = 8;
     private static final int UPGRADE_PLUS_BLOCK = 3;
 
     public Rest() {

--- a/src/main/java/stsjorbsmod/cards/wanderer/SiphonEnergy.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/SiphonEnergy.java
@@ -24,8 +24,8 @@ public class SiphonEnergy extends CustomJorbsModCard {
     public static final CardColor COLOR = Wanderer.Enums.WANDERER_CARD_COLOR;
 
     private static final int COST = 1;
-    private static final int CARD_DRAW = 3;
-    private static final int UPGRADE_PLUS_CARD_DRAW = 2;
+    private static final int CARD_DRAW = 2;
+    private static final int UPGRADE_PLUS_CARD_DRAW = 1;
     private static final int BASE_ENERGY_GAIN = 0;
     private static final int ENERGY_GAIN_PER_CLARITY = 1;
 

--- a/src/main/java/stsjorbsmod/cards/wanderer/TollTheDead.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/TollTheDead.java
@@ -21,7 +21,7 @@ public class TollTheDead extends CustomJorbsModCard {
     public static final CardColor COLOR = Wanderer.Enums.WANDERER_CARD_COLOR;
 
     private static final int COST = 1;
-    private static final int DAMAGE = 8;
+    private static final int DAMAGE = 7;
     private static final int UPGRADE_PLUS_DMG = 2;
 
     public TollTheDead() {

--- a/src/main/java/stsjorbsmod/cards/wanderer/Trauma.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/Trauma.java
@@ -26,13 +26,13 @@ public class Trauma extends CustomJorbsModCard {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
         damage = baseDamage = DAMAGE;
         isMultiDamage = true;
+        shuffleBackIntoDrawPile = true;
     }
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
         addToBot(new SnapAction(p));
         addToBot(new DamageAllEnemiesAction(p, multiDamage, damageTypeForTurn, AttackEffect.BLUNT_HEAVY));
-        CardReboundField.reboundOnce.set(this, true);
     }
 
     @Override

--- a/src/main/java/stsjorbsmod/cards/wanderer/materialcomponents/Chamomile.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/materialcomponents/Chamomile.java
@@ -40,8 +40,6 @@ public class Chamomile extends MaterialComponent {
     public void upgrade() {
         if (!upgraded) {
             upgradeName();
-            EphemeralField.ephemeral.set(this, false);
-            exhaust = true;
             upgradeDescription();
         }
     }

--- a/src/main/java/stsjorbsmod/cards/wanderer/materialcomponents/Chamomile.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/materialcomponents/Chamomile.java
@@ -30,7 +30,9 @@ public class Chamomile extends MaterialComponent {
     @Override
     public void useMaterialComponent(AbstractPlayer p, AbstractMonster m) {
         addToBot(new RemoveSpecificPowerAction(p, p, FrailPower.POWER_ID));
-        addToBot(new RemoveSpecificPowerAction(p, p, VulnerablePower.POWER_ID));
+        if (upgraded) {
+            addToBot(new RemoveSpecificPowerAction(p, p, VulnerablePower.POWER_ID));
+        }
         addToBot(new RemoveSpecificPowerAction(p, p, WeakPower.POWER_ID));
     }
 
@@ -39,7 +41,6 @@ public class Chamomile extends MaterialComponent {
         if (!upgraded) {
             upgradeName();
             EphemeralField.ephemeral.set(this, false);
-            selfRetain = true;
             exhaust = true;
             upgradeDescription();
         }

--- a/src/main/java/stsjorbsmod/cards/wanderer/materialcomponents/Quicksilver.java
+++ b/src/main/java/stsjorbsmod/cards/wanderer/materialcomponents/Quicksilver.java
@@ -18,7 +18,7 @@ public class Quicksilver extends MaterialComponent {
     private static final CardType TYPE = CardType.SKILL;
     public static final CardColor COLOR = Wanderer.Enums.WANDERER_CARD_COLOR;
 
-    private static final int COST = 0;
+    private static final int COST = 1;
     private static final int RELIC_COUNTER_INCREMENT = 1;
     private static final int NEXT_ATTACK_ADDITIONAL_TIMES = 1;
     private static final int UPGRADE_PLUS_NEXT_ATTACK_ADDITIONAL_TIMES = 1;

--- a/src/main/java/stsjorbsmod/memories/MemoryManager.java
+++ b/src/main/java/stsjorbsmod/memories/MemoryManager.java
@@ -196,6 +196,7 @@ public class MemoryManager {
         owner.relics.forEach(possibleListener -> notifyPossibleModifyMemorySubscriber(possibleListener, callback));
         owner.powers.forEach(possibleListener -> notifyPossibleModifyMemorySubscriber(possibleListener, callback));
         this.memories.forEach(possibleListener -> notifyPossibleModifyMemorySubscriber(possibleListener, callback));
+        // FreshAdventure's onSnap relies on exactly one version of a given uuid being notified; revisit it if we ever add hand/discard/exhaust notifications
         owner.masterDeck.group.forEach(possibleListener -> notifyPossibleModifyMemorySubscriber(possibleListener, callback));
 
         AbstractDungeon.onModifyPower();

--- a/src/main/java/stsjorbsmod/memories/MemoryManager.java
+++ b/src/main/java/stsjorbsmod/memories/MemoryManager.java
@@ -196,6 +196,7 @@ public class MemoryManager {
         owner.relics.forEach(possibleListener -> notifyPossibleModifyMemorySubscriber(possibleListener, callback));
         owner.powers.forEach(possibleListener -> notifyPossibleModifyMemorySubscriber(possibleListener, callback));
         this.memories.forEach(possibleListener -> notifyPossibleModifyMemorySubscriber(possibleListener, callback));
+        owner.masterDeck.group.forEach(possibleListener -> notifyPossibleModifyMemorySubscriber(possibleListener, callback));
 
         AbstractDungeon.onModifyPower();
     }

--- a/src/main/java/stsjorbsmod/powers/BookOfTonguesPower.java
+++ b/src/main/java/stsjorbsmod/powers/BookOfTonguesPower.java
@@ -8,18 +8,12 @@ import stsjorbsmod.actions.MakeMaterialComponentsInHandAction;
 public class BookOfTonguesPower extends CustomJorbsModPower {
     public static final StaticPowerInfo STATIC = StaticPowerInfo.Load(BookOfTonguesPower.class);
     public static final String POWER_ID = STATIC.ID;
-    private final boolean upgraded;
 
-    public BookOfTonguesPower(final AbstractCreature owner, final int cardsPerTurn, final boolean upgraded) {
+    public BookOfTonguesPower(final AbstractCreature owner, final int cardsPerTurn) {
         super(STATIC);
-        if (upgraded) {
-            this.ID += "_upgraded"; // This ensures that the upgraded version stacks separately
-            this.name += "+";
-        }
 
         this.owner = owner;
         this.amount = cardsPerTurn;
-        this.upgraded = upgraded;
 
         updateDescription();
     }
@@ -27,22 +21,18 @@ public class BookOfTonguesPower extends CustomJorbsModPower {
     public void atStartOfTurn() {
         if (!AbstractDungeon.getMonsters().areMonstersBasicallyDead()) {
             flash();
-            AbstractDungeon.actionManager.addToBottom(new MakeMaterialComponentsInHandAction(amount, upgraded));
+            AbstractDungeon.actionManager.addToBottom(new MakeMaterialComponentsInHandAction(amount, false));
         }
     }
 
     @Override
     public void updateDescription() {
-        if (upgraded) {
-            description = String.format(this.amount == 1 ? DESCRIPTIONS[2] : DESCRIPTIONS[3], this.amount);
-        } else {
-            description = String.format(this.amount == 1 ? DESCRIPTIONS[0] : DESCRIPTIONS[1], this.amount);
-        }
+        description = String.format(this.amount == 1 ? DESCRIPTIONS[0] : DESCRIPTIONS[1], this.amount);
     }
 
     @Override
     public AbstractPower makeCopy() {
-        return new BookOfTonguesPower(owner, amount, upgraded);
+        return new BookOfTonguesPower(owner, amount);
     }
 }
 

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -631,7 +631,7 @@
   },
   "stsjorbsmod:Trauma": {
     "NAME": "Trauma",
-    "DESCRIPTION": "stsjorbsmod:Snap. NL Deal !D! damage to ALL enemies. NL Put this card on top of your draw pile."
+    "DESCRIPTION": "stsjorbsmod:Snap. NL Deal !D! damage to ALL enemies. NL Shuffle this card into your draw pile."
   },
   "stsjorbsmod:Trouble": {
     "NAME": "Trouble",

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -285,6 +285,7 @@
   "stsjorbsmod:Hurt": {
     "NAME": "Hurt",
     "DESCRIPTION": "Deal !D! damage. NL Lose HP equal to the number of stsjorbsmod:Clarities you have.",
+    "UPGRADE_DESCRIPTION": "Deal !D! damage. NL Lose HP equal to the number of stsjorbsmod:Clarities you have. NL Gain stsjorbsmod:Clarity of current memory.",
     "EXTENDED_DESCRIPTION": [
       " NL (Lose !M! HP.)"
     ]

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -256,7 +256,7 @@
   },
   "stsjorbsmod:FreshAdventure": {
     "NAME": "Fresh Adventure",
-    "DESCRIPTION": "Deal !D! damage. NL Remember stsjorbsmod:Diligence."
+    "DESCRIPTION": "Deal !D! damage. NL Remember stsjorbsmod:Diligence. NL This card gains !M! damage permanently when you stsjorbsmod:Snap."
   },
   "stsjorbsmod:Frostbite": {
     "NAME": "Frostbite",

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -101,7 +101,8 @@
   },
   "stsjorbsmod:ChatteringStrike": {
     "NAME": "Chattering Strike",
-    "DESCRIPTION": "Deal !D! damage. NL Play this card !M! additional time."
+    "DESCRIPTION": "Deal !D! damage. NL Play this card !M! additional time.",
+    "DESCRIPTIONS": "Deal !D! damage. NL Play this card !M! additional times."
   },
   "stsjorbsmod:ChillTouch": {
     "NAME": "Chill Touch",

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -286,7 +286,6 @@
   "stsjorbsmod:Hurt": {
     "NAME": "Hurt",
     "DESCRIPTION": "Deal !D! damage. NL Lose HP equal to the number of stsjorbsmod:Clarities you have.",
-    "UPGRADE_DESCRIPTION": "Deal !D! damage. NL Lose HP equal to the number of stsjorbsmod:Clarities you have. NL Gain stsjorbsmod:Clarity of current memory.",
     "EXTENDED_DESCRIPTION": [
       " NL (Lose !M! HP.)"
     ]

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -82,7 +82,7 @@
   },
   "stsjorbsmod:Chamomile": {
     "NAME": "Chamomile",
-    "DESCRIPTION": "stsjorbsmod:Ephemeral. NL Remove Frail, and Weak from yourself.",
+    "DESCRIPTION": "stsjorbsmod:Ephemeral. NL Remove Frail and Weak from yourself.",
     "UPGRADE_DESCRIPTION": "stsjorbsmod:Ephemeral. NL Remove Frail, Vulnerable, and Weak from yourself."
   },
   "stsjorbsmod:Channel": {
@@ -102,7 +102,7 @@
   "stsjorbsmod:ChatteringStrike": {
     "NAME": "Chattering Strike",
     "DESCRIPTION": "Deal !D! damage. NL Play this card !M! additional time.",
-    "DESCRIPTIONS": "Deal !D! damage. NL Play this card !M! additional times."
+    "UPGRADE_DESCRIPTION": "Deal !D! damage. NL Play this card !M! additional times."
   },
   "stsjorbsmod:ChillTouch": {
     "NAME": "Chill Touch",
@@ -140,7 +140,8 @@
   },
   "stsjorbsmod:DeathThroes": {
     "NAME": "Death Throes",
-    "DESCRIPTION": "stsjorbsmod:Entombed. stsjorbsmod:Ephemeral. NL stsjorbsmod:Exhume whenever an enemy dies. NL Deal !D! damage. NL Remember stsjorbsmod:Wrath."
+    "DESCRIPTION": "stsjorbsmod:Entombed. stsjorbsmod:Ephemeral. NL stsjorbsmod:Exhume whenever an enemy dies. NL Deal !D! damage. NL Remember stsjorbsmod:Wrath.",
+    "UPGRADE_DESCRIPTION": "stsjorbsmod:Entombed. stsjorbsmod:Ephemeral. NL stsjorbsmod:Exhume whenever an enemy dies. NL Deal !D! damage. NL Gain stsjorbsmod:Clarity of stsjorbsmod:Wrath."
   },
   "stsjorbsmod:Defend_Wanderer": {
     "NAME": "Defend",
@@ -264,7 +265,7 @@
   },
   "stsjorbsmod:GatherPower": {
     "NAME": "Gather Power",
-    "DESCRIPTION": "Draw !M! cards. NL This turn, your next attack is played !stsjorbsmod:MetaMagic! additional time.",
+    "DESCRIPTION": "Draw !M! card. NL This turn, your next attack is played !stsjorbsmod:MetaMagic! additional time.",
     "UPGRADE_DESCRIPTION": "Draw !M! cards. NL This turn, your next attack is played !stsjorbsmod:MetaMagic! additional times."
   },
   "stsjorbsmod:Haunt": {

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -54,7 +54,7 @@
   "stsjorbsmod:BookOfTongues": {
     "NAME": "Book of Tongues",
     "DESCRIPTION": "At the start of each turn, put !M! stsjorbsmod:Material\u00a0Component into your hand.",
-    "UPGRADE_DESCRIPTION": "At the start of each turn, put !M! Upgraded stsjorbsmod:Material\u00a0Component into your hand."
+    "UPGRADE_DESCRIPTION": "Innate. NL At the start of each turn, put !M! stsjorbsmod:Material\u00a0Component into your hand."
   },
   "stsjorbsmod:Brambles": {
     "NAME": "Brambles",

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -82,8 +82,8 @@
   },
   "stsjorbsmod:Chamomile": {
     "NAME": "Chamomile",
-    "DESCRIPTION": "stsjorbsmod:Ephemeral. NL Remove Frail, Vulnerable, and Weak from yourself.",
-    "UPGRADE_DESCRIPTION": "Retain. NL Remove Frail, Vulnerable, and Weak from yourself. NL Exhaust."
+    "DESCRIPTION": "stsjorbsmod:Ephemeral. NL Remove Frail, and Weak from yourself.",
+    "UPGRADE_DESCRIPTION": "stsjorbsmod:Ephemeral. NL Remove Frail, Vulnerable, and Weak from yourself."
   },
   "stsjorbsmod:Channel": {
     "NAME": "Channel",

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Power-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Power-Strings.json
@@ -21,9 +21,7 @@
     "NAME": "Book of Tongues",
     "DESCRIPTIONS": [
       "At the start of your turn, draw #b%1$s random Material Component.",
-      "At the start of your turn, draw #b%1$s random Material Components.",
-      "At the start of your turn, draw #b%1$s random Upgraded Material Component.",
-      "At the start of your turn, draw #b%1$s random Upgraded Material Components."
+      "At the start of your turn, draw #b%1$s random Material Components."
     ]
   },
   "stsjorbsmod:BurningPower": {


### PR DESCRIPTION
- fresh adventure: -1 damage, "this card gains a wrath stack every time you snap"
- chamomile: loses vulnerable, upgrades to have vulnerable (no retain)
- quicksilver: costs 1
- burning flask: -1 burning
- chattering strike: upgrades to deal 4 damage, play this card 2 additional times
- hibernate: -1 block
- hurt: no increased damage on upgrade, upgrade adds gain clarity of current memory, still loses life per clarity
- materialize: costs 1, +1 block
- book of tongues: upgrades to innate instead of upgraded components
- flame ward: -1 burning, -1 block
- rest: -2 block
- toll the dead: -1 damage
- death throes+: no damage increase, no remember wrath, gain clarity of wrath
- gather power: -1 card draw
- trauma: shuffle into draw pile instead of put on top
- siphon energy: draw 2 cards (3 on upgrade)
- rediscovery: costs 1, upgrades to innate at 1 cost