### PR TITLE
Diligence uses the old hook, Chastity uses a newer hook

### DIFF
--- a/src/main/java/stsjorbsmod/actions/TimeEddyAction.java
+++ b/src/main/java/stsjorbsmod/actions/TimeEddyAction.java
@@ -56,7 +56,8 @@ public class TimeEddyAction extends AbstractGameAction {
     @Override
     public void update() {
         // Player turn end
-        forEachApplicablePlayerMemory(m -> m.atEndOfTurn());
+        forEachApplicablePlayerMemory(m -> m.atEndOfTurnPreEndTurnCards());
+        forEachApplicablePlayerMemory(m -> m.atEndOfTurn(true));
         forEachApplicablePlayerPower(p -> p.atEndOfTurnPreEndTurnCards(true));
         forEachApplicablePlayerPower(p -> p.atEndOfTurn(true));
 

--- a/src/main/java/stsjorbsmod/memories/AbstractMemory.java
+++ b/src/main/java/stsjorbsmod/memories/AbstractMemory.java
@@ -105,7 +105,8 @@ public abstract class AbstractMemory implements OnModifyGoldSubscriber {
     // ** Be sure to check isPassiveEffectActive as necessary. **
     @Override public void onModifyGold(AbstractPlayer p) {}
     public void atStartOfTurnPostDraw() {}
-    public void atEndOfTurn() {}
+    public void atEndOfTurnPreEndTurnCards() {}
+    public void atEndOfTurn(boolean isPlayer) {}
     public void onPlayCard(AbstractCard card, AbstractMonster monster) { }
     public void onAttack(DamageInfo info, int damageAmount, AbstractCreature target) { }
     // onMonsterDeath can happen within the same action that ends the combat, so you shouldn't queue new actions in here.

--- a/src/main/java/stsjorbsmod/memories/ChastityMemory.java
+++ b/src/main/java/stsjorbsmod/memories/ChastityMemory.java
@@ -41,7 +41,7 @@ public class ChastityMemory extends AbstractMemory {
     }
 
     @Override
-    public void atEndOfTurn() {
+    public void atEndOfTurnPreEndTurnCards() {
         if (isPassiveEffectActive()) {
             AbstractDungeon.actionManager.addToBottom(
                     // It's important to apply a negative dex power rather than reducing an existing dex power

--- a/src/main/java/stsjorbsmod/memories/DiligenceMemory.java
+++ b/src/main/java/stsjorbsmod/memories/DiligenceMemory.java
@@ -26,8 +26,9 @@ public class DiligenceMemory extends AbstractMemory {
     }
 
     @Override
-    public void atEndOfTurn() {
-        if (isPassiveEffectActive() &&
+    public void atEndOfTurn(boolean isPlayer) {
+        if (isPlayer &&
+            isPassiveEffectActive() &&
             // Similar to Well-Laid Plans' RetainCardPower...
             !AbstractDungeon.player.hand.isEmpty() &&
             !AbstractDungeon.player.hasRelic(RunicPyramid.ID) &&

--- a/src/main/java/stsjorbsmod/patches/MemoryHooksPatch.java
+++ b/src/main/java/stsjorbsmod/patches/MemoryHooksPatch.java
@@ -71,7 +71,15 @@ public class MemoryHooksPatch {
     public static class callEndOfTurnActionsHook {
         @SpirePrefixPatch
         public static void patch(GameActionManager __this) {
-            forEachMemory(AbstractDungeon.player, m -> m.atEndOfTurn());
+            forEachMemory(AbstractDungeon.player, m -> m.atEndOfTurnPreEndTurnCards());
+        }
+    }
+
+    @SpirePatch(clz = AbstractCreature.class,  method = "applyEndOfTurnTriggers")
+    public static class atEndOfTurnHook {
+        @SpirePostfixPatch
+        public static void patch(AbstractCreature __this) {
+            forEachMemory(__this, m -> m.atEndOfTurn(__this.isPlayer));
         }
     }
 


### PR DESCRIPTION
- Brought back the old memory end turn hook for Diligence to use
- Renamed memory end turn hook to `atEndOfTurnPreEndTurnCards` for Chastity to use
- Time Eddy triggers both end turn memory hooks