### PR TITLE
Humility amnesia negative thorns

### DIFF
--- a/src/main/java/stsjorbsmod/memories/HumilityMemory.java
+++ b/src/main/java/stsjorbsmod/memories/HumilityMemory.java
@@ -8,8 +8,6 @@ import com.megacrit.cardcrawl.powers.AbstractPower;
 import com.megacrit.cardcrawl.powers.ThornsPower;
 import stsjorbsmod.util.ReflectionUtils;
 
-import java.util.stream.Collectors;
-
 public class HumilityMemory extends AbstractMemory implements OnPowersModifiedSubscriber {
     public static final StaticMemoryInfo STATIC = StaticMemoryInfo.Load(HumilityMemory.class);
 
@@ -33,13 +31,18 @@ public class HumilityMemory extends AbstractMemory implements OnPowersModifiedSu
 
     private int calculateBonusThorns() {
         AbstractPower maybeThornsPower = owner == null ? null : owner.getPower(ThornsPower.POWER_ID);
-        int currentThornsStacks = maybeThornsPower == null ? 0 : maybeThornsPower.amount;
+        int currentThornsStacks = 0;
+        if (maybeThornsPower == null) {
+            thornsAlreadyApplied = 0;
+        } else {
+            currentThornsStacks = maybeThornsPower.amount;
+        }
         int pendingThornsStacks = AbstractDungeon.actionManager.actions
                 .stream()
                 .filter(a ->
                         a instanceof ApplyPowerAction &&
-                        a.target == owner &&
-                        ReflectionUtils.getPrivateField((ApplyPowerAction) a, ApplyPowerAction.class, "powerToApply") instanceof ThornsPower)
+                                a.target == owner &&
+                                ReflectionUtils.getPrivateField((ApplyPowerAction) a, ApplyPowerAction.class, "powerToApply") instanceof ThornsPower)
                 .mapToInt(a -> a.amount)
                 .sum();
 

--- a/src/main/java/stsjorbsmod/memories/HumilityMemory.java
+++ b/src/main/java/stsjorbsmod/memories/HumilityMemory.java
@@ -33,6 +33,7 @@ public class HumilityMemory extends AbstractMemory implements OnPowersModifiedSu
         AbstractPower maybeThornsPower = owner == null ? null : owner.getPower(ThornsPower.POWER_ID);
         int currentThornsStacks = 0;
         if (maybeThornsPower == null) {
+            // if the owner does not have thorns, then the base thorns amount is 0
             thornsAlreadyApplied = 0;
         } else {
             currentThornsStacks = maybeThornsPower.amount;

--- a/src/main/java/stsjorbsmod/memories/HumilityMemory.java
+++ b/src/main/java/stsjorbsmod/memories/HumilityMemory.java
@@ -42,8 +42,8 @@ public class HumilityMemory extends AbstractMemory implements OnPowersModifiedSu
                 .stream()
                 .filter(a ->
                         a instanceof ApplyPowerAction &&
-                                a.target == owner &&
-                                ReflectionUtils.getPrivateField((ApplyPowerAction) a, ApplyPowerAction.class, "powerToApply") instanceof ThornsPower)
+                        a.target == owner &&
+                        ReflectionUtils.getPrivateField((ApplyPowerAction) a, ApplyPowerAction.class, "powerToApply") instanceof ThornsPower)
                 .mapToInt(a -> a.amount)
                 .sum();
 


### PR DESCRIPTION
Prevent thorns from going negative when amnesia or other similar effects remove thorns rather than reduce thorns. Do this by checking if thorns is null and setting `thornsAlreadyApplied` to 0 if true.