### PR TITLE
Implement API to communicate with Twitch extension

### DIFF
--- a/src/main/java/stsjorbsmod/characters/Wanderer.java
+++ b/src/main/java/stsjorbsmod/characters/Wanderer.java
@@ -474,10 +474,23 @@ public class Wanderer extends CustomPlayer implements OnResetPlayerSubscriber {
 
     @Override
     public void update() {
-        TwitchExtensionAPI.clearLists();
         super.update();
         int flipMultiplier = flipHorizontal ? -1 : 1;
         snapCounter.update(drawX + flipMultiplier * SNAP_COUNTER_OFFSET_X, drawY + SNAP_COUNTER_OFFSET_Y, flipMultiplier);
+        updateTwitchExtensionAPI();
+    }
+
+    private void updateTwitchExtensionAPI() {
+        TwitchExtensionAPI.clearLists();
+
+        MemoryManager manager = MemoryManager.forPlayer();
+        if (!manager.isSnapped()) {
+            for (int i = 0; i < manager.memories.size(); ++i) {
+                TwitchExtensionAPI.addPowerTips(manager.memories.get(i).hb, manager.memories.get(i).getTips());
+            }
+
+            TwitchExtensionAPI.addPowerTips(snapCounter.hb, snapCounter.tips);
+        }
     }
 
     @Override

--- a/src/main/java/stsjorbsmod/characters/Wanderer.java
+++ b/src/main/java/stsjorbsmod/characters/Wanderer.java
@@ -35,6 +35,7 @@ import stsjorbsmod.memories.SnapCounter;
 import stsjorbsmod.patches.CutsceneMultiScreenPatch;
 import stsjorbsmod.powers.EntombedGrimoirePower;
 import stsjorbsmod.relics.GrimoireRelic;
+import stsjorbsmod.twitch.TwitchExtensionAPI;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -473,6 +474,7 @@ public class Wanderer extends CustomPlayer implements OnResetPlayerSubscriber {
 
     @Override
     public void update() {
+        TwitchExtensionAPI.clearLists();
         super.update();
         int flipMultiplier = flipHorizontal ? -1 : 1;
         snapCounter.update(drawX + flipMultiplier * SNAP_COUNTER_OFFSET_X, drawY + SNAP_COUNTER_OFFSET_Y, flipMultiplier);

--- a/src/main/java/stsjorbsmod/memories/AbstractMemory.java
+++ b/src/main/java/stsjorbsmod/memories/AbstractMemory.java
@@ -73,7 +73,7 @@ public abstract class AbstractMemory implements OnModifyGoldSubscriber {
     private static Color ICON_COLOR = Settings.CREAM_COLOR.cpy();
     private float centerX;
     private float centerY;
-    protected Hitbox hb;
+    public Hitbox hb;
     private float rememberBgRotationTimer = 0.0F;
     private ArrayList<AbstractGameEffect> renderEffects = new ArrayList<>();
 
@@ -161,7 +161,7 @@ public abstract class AbstractMemory implements OnModifyGoldSubscriber {
 
     protected void addExtraPowerTips(ArrayList<PowerTip> tips) { }
 
-    protected ArrayList<PowerTip> getTips() {
+    public ArrayList<PowerTip> getTips() {
         ArrayList<PowerTip> tips = new ArrayList<>();
         tips.add(new PowerTip(name, description, staticInfo.CLARITY_IMG_48));
         addExtraPowerTips(tips);

--- a/src/main/java/stsjorbsmod/memories/AbstractMemory.java
+++ b/src/main/java/stsjorbsmod/memories/AbstractMemory.java
@@ -73,7 +73,7 @@ public abstract class AbstractMemory implements OnModifyGoldSubscriber {
     private static Color ICON_COLOR = Settings.CREAM_COLOR.cpy();
     private float centerX;
     private float centerY;
-    private Hitbox hb;
+    protected Hitbox hb;
     private float rememberBgRotationTimer = 0.0F;
     private ArrayList<AbstractGameEffect> renderEffects = new ArrayList<>();
 
@@ -161,10 +161,16 @@ public abstract class AbstractMemory implements OnModifyGoldSubscriber {
 
     protected void addExtraPowerTips(ArrayList<PowerTip> tips) { }
 
-    private void renderTip() {
+    protected ArrayList<PowerTip> getTips() {
         ArrayList<PowerTip> tips = new ArrayList<>();
         tips.add(new PowerTip(name, description, staticInfo.CLARITY_IMG_48));
         addExtraPowerTips(tips);
+
+        return tips;
+    }
+
+    private void renderTip() {
+        ArrayList<PowerTip> tips = getTips();
 
         // Based on the AbstractCreature.renderPowerTips impl
         float tipX = centerX + hb.width / 2.0F < TIP_X_THRESHOLD ?

--- a/src/main/java/stsjorbsmod/memories/MemoryManager.java
+++ b/src/main/java/stsjorbsmod/memories/MemoryManager.java
@@ -20,7 +20,7 @@ public class MemoryManager {
     private final AbstractPlayer owner;
 
     public AbstractMemory currentMemory;
-    private ArrayList<AbstractMemory> memories;
+    public ArrayList<AbstractMemory> memories;
     public boolean renderForgottenMemories = false;
 
     public MemoryManager(AbstractPlayer owner) {
@@ -236,8 +236,6 @@ public class MemoryManager {
             float y = MEMORY_ARC_Y_RADIUS * MathUtils.sinDeg(absoluteAngle) + centerY + MEMORY_ARC_Y_OFFSET;
 
             memories.get(i).update(x, y);
-
-            TwitchExtensionAPI.addPowerTips(memories.get(i).hb, memories.get(i).getTips());
         }
     }
 

--- a/src/main/java/stsjorbsmod/memories/MemoryManager.java
+++ b/src/main/java/stsjorbsmod/memories/MemoryManager.java
@@ -7,9 +7,9 @@ import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.AbstractPower;
-import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.patches.PlayerMemoryManagerPatch;
 import stsjorbsmod.powers.SnappedPower;
+import stsjorbsmod.twitch.TwitchExtensionAPI;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -236,6 +236,8 @@ public class MemoryManager {
             float y = MEMORY_ARC_Y_RADIUS * MathUtils.sinDeg(absoluteAngle) + centerY + MEMORY_ARC_Y_OFFSET;
 
             memories.get(i).update(x, y);
+
+            TwitchExtensionAPI.addPowerTips(memories.get(i).hb, memories.get(i).getTips());
         }
     }
 

--- a/src/main/java/stsjorbsmod/memories/SnapCounter.java
+++ b/src/main/java/stsjorbsmod/memories/SnapCounter.java
@@ -10,7 +10,9 @@ import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
-import com.megacrit.cardcrawl.helpers.*;
+import com.megacrit.cardcrawl.helpers.Hitbox;
+import com.megacrit.cardcrawl.helpers.PowerTip;
+import com.megacrit.cardcrawl.helpers.TipHelper;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.rooms.MonsterRoom;
@@ -20,6 +22,7 @@ import stsjorbsmod.effects.SnapTurnCounterEffect;
 import stsjorbsmod.powers.FragilePower;
 import stsjorbsmod.tips.MemoryFtueTip;
 import stsjorbsmod.tips.SnapFtueTip;
+import stsjorbsmod.twitch.TwitchExtensionAPI;
 
 import java.util.ArrayList;
 
@@ -173,6 +176,8 @@ public class SnapCounter {
                 AbstractDungeon.effectList.add(new SnapTurnCounterEffect(x, y, color, scaleModifier));
             }
         }
+
+        TwitchExtensionAPI.addPowerTips(hb, tips);
     }
 
     public void renderTips(SpriteBatch sb) {

--- a/src/main/java/stsjorbsmod/memories/SnapCounter.java
+++ b/src/main/java/stsjorbsmod/memories/SnapCounter.java
@@ -47,8 +47,8 @@ public class SnapCounter {
     public static final int SNAP_TURN = 7;
 
     private final AbstractPlayer owner;
-    private final Hitbox hb;
-    private final ArrayList<PowerTip> tips;
+    public final Hitbox hb;
+    public final ArrayList<PowerTip> tips;
 
     private float centerX;
     private float centerY;
@@ -176,8 +176,6 @@ public class SnapCounter {
                 AbstractDungeon.effectList.add(new SnapTurnCounterEffect(x, y, color, scaleModifier));
             }
         }
-
-        TwitchExtensionAPI.addPowerTips(hb, tips);
     }
 
     public void renderTips(SpriteBatch sb) {

--- a/src/main/java/stsjorbsmod/twitch/TwitchExtensionAPI.java
+++ b/src/main/java/stsjorbsmod/twitch/TwitchExtensionAPI.java
@@ -1,0 +1,52 @@
+package stsjorbsmod.twitch;
+
+import basemod.BaseMod;
+import basemod.interfaces.PostUpdateSubscriber;
+import com.evacipated.cardcrawl.modthespire.lib.SpireInitializer;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.helpers.Hitbox;
+import com.megacrit.cardcrawl.helpers.PowerTip;
+
+import java.util.ArrayList;
+
+@SpireInitializer
+public class TwitchExtensionAPI implements PostUpdateSubscriber {
+
+    // =============== API for SlayTheRelics for displaying tooltips on Twitch =================
+    //
+    // -------> See <INSERT FUTURE LINK TO THE DOCS> for the documentation of this API <--------
+    //
+    // These two properties are read by another mod that sends their contents over to a Twitch extension called
+    // SlayTheRelics and they are displayed alongside other tooltips.
+    public static ArrayList<Hitbox> slayTheRelicsHitboxes = new ArrayList<>();
+    public static ArrayList<ArrayList<PowerTip>> slayTheRelicsPowerTips = new ArrayList<>();
+
+    public static TwitchExtensionAPI instance;
+
+    public static void initialize() {
+        instance = new TwitchExtensionAPI();
+    }
+
+    TwitchExtensionAPI() {
+         BaseMod.subscribe(this);
+    }
+
+    public static void clearLists() {
+        slayTheRelicsHitboxes.clear();
+        slayTheRelicsPowerTips.clear();
+    }
+
+    public static void addPowerTips(Hitbox hitbox, ArrayList<PowerTip> tips) {
+        slayTheRelicsHitboxes.add(hitbox);
+        slayTheRelicsPowerTips.add(tips);
+    }
+
+    // This ensures that the shared array lists will be empty even after the player exits a run, no matter how,
+    // whether they win, lose, save&exit or abandon the run.
+    @Override
+    public void receivePostUpdate() {
+        if (!CardCrawlGame.isInARun()) {
+            clearLists();
+        }
+    }
+}


### PR DESCRIPTION
Implements API that allows displaying PowerTips on Twitch for streamers using SlayTheRelics Twitch extension


- The TwitchExtension allows to display the actual PowerTips of Memories and the Snap Counter on stream

- The data is shared through two static ArrayLists: slayTheRelicsHitboxes, slayTheRelicsPowerTips

- The specific properties are looked up (by name) by the SlayTheRelicsExporter mod (in all classes that have @SpireInitializer), if they are found, they are checked frequently and their contents are sent over to a server that communicates with Twitch

- Here, during every update of the Wanderer both ArrayLists are cleared and refilled. This is perhaps not the most optimal approach but probably the simplest with the smallest footprint. Impact on performance should be negligable.

- Documentation for the API will be available soon (tm), the extension is expected to be released within 1-3 weeks (2020/4/5 - 2020/4/19)

- The changes **have been tested** reasonably with mentioned mod and extension directly on Twitch.

<!--
Thanks for contributing to Jorbs's Wanderer Trilogy!

Before sending your PR, we recommend:

* For large or complicated changes, discuss it first at https://discord.gg/jorbs
* Reference any related issues (eg, "fixes #123") in your PR description
* If the change is user-facing, include bullet point(s) in CHANGELOG.md's [Unreleased] section describing the change for players
* If you are a new contributor, welcome! Feel free to add your name to /docs/credits.md in whichever format you'd like to appear!

See CONTRIBUTING.md for more information and guidance, or come ask questions at https://discord.gg/jorbs
-->