### PR TITLE
Add integration for SlayTheRelics Twitch extension

### DIFF
--- a/src/main/java/stsjorbsmod/memories/AbstractMemory.java
+++ b/src/main/java/stsjorbsmod/memories/AbstractMemory.java
@@ -26,6 +26,7 @@ import com.megacrit.cardcrawl.vfx.combat.SilentGainPowerEffect;
 import stsjorbsmod.JorbsMod;
 import stsjorbsmod.powers.OnModifyGoldSubscriber;
 import stsjorbsmod.tips.MemoryFtueTip;
+import stsjorbsmod.twitch.SlayTheRelicsIntegration;
 import stsjorbsmod.util.RenderUtils;
 import stsjorbsmod.util.TextureLoader;
 
@@ -157,14 +158,22 @@ public abstract class AbstractMemory implements OnModifyGoldSubscriber {
         if ((!AbstractDungeon.isScreenUp || PeekButton.isPeeking) && hb.hovered) {
             renderTip();
         }
+
+        SlayTheRelicsIntegration.renderTipHitbox(hb, getTips());
     }
 
     protected void addExtraPowerTips(ArrayList<PowerTip> tips) { }
 
-    private void renderTip() {
+    private ArrayList<PowerTip> getTips() {
         ArrayList<PowerTip> tips = new ArrayList<>();
         tips.add(new PowerTip(name, description, staticInfo.CLARITY_IMG_48));
         addExtraPowerTips(tips);
+
+        return tips;
+    }
+
+    private void renderTip() {
+        ArrayList<PowerTip> tips = getTips();
 
         // Based on the AbstractCreature.renderPowerTips impl
         float tipX = centerX + hb.width / 2.0F < TIP_X_THRESHOLD ?

--- a/src/main/java/stsjorbsmod/memories/SnapCounter.java
+++ b/src/main/java/stsjorbsmod/memories/SnapCounter.java
@@ -20,6 +20,7 @@ import stsjorbsmod.effects.SnapTurnCounterEffect;
 import stsjorbsmod.powers.FragilePower;
 import stsjorbsmod.tips.MemoryFtueTip;
 import stsjorbsmod.tips.SnapFtueTip;
+import stsjorbsmod.twitch.SlayTheRelicsIntegration;
 
 import java.util.ArrayList;
 
@@ -190,6 +191,8 @@ public class SnapCounter {
     }
 
     public void render(SpriteBatch sb) {
-        // We don't currently render anything directly; it's indirect via the effects added in update()
+        if (!isVisible()) { return; }
+
+        SlayTheRelicsIntegration.renderTipHitbox(hb, tips);
     }
 }

--- a/src/main/java/stsjorbsmod/twitch/SlayTheRelicsIntegration.java
+++ b/src/main/java/stsjorbsmod/twitch/SlayTheRelicsIntegration.java
@@ -1,0 +1,36 @@
+package stsjorbsmod.twitch;
+
+import basemod.BaseMod;
+import basemod.interfaces.PreRenderSubscriber;
+import com.evacipated.cardcrawl.modthespire.lib.SpireInitializer;
+import com.megacrit.cardcrawl.helpers.Hitbox;
+import com.megacrit.cardcrawl.helpers.PowerTip;
+
+import java.util.ArrayList;
+
+@SpireInitializer
+public class SlayTheRelicsIntegration {
+
+    // =============== API for SlayTheRelics for displaying tooltips on Twitch =================
+    //
+    // -------> See <INSERT FUTURE LINK TO THE DOCS> for the documentation of this API <--------
+    //
+    // These two properties are read by another mod that sends their contents over to a Twitch extension called
+    // SlayTheRelics and they are displayed alongside other tooltips on stream
+    public static ArrayList<Hitbox> slayTheRelicsHitboxes = new ArrayList<>();
+    public static ArrayList<ArrayList<PowerTip>> slayTheRelicsPowerTips = new ArrayList<>();
+
+    public static void initialize() {
+        BaseMod.subscribe((PreRenderSubscriber) (orthographicCamera) -> clear());
+    }
+
+    private static void clear() {
+        slayTheRelicsHitboxes.clear();
+        slayTheRelicsPowerTips.clear();
+    }
+
+    public static void renderTipHitbox(Hitbox hb, ArrayList<PowerTip> tips) {
+        slayTheRelicsHitboxes.add(hb);
+        slayTheRelicsPowerTips.add(tips);
+    }
+}


### PR DESCRIPTION
 - allows rendering PowerTips on stream, this integration allows rendering of custom
   PowerTips unique to this mod - the memories and the snap counter

 - tested live on twitch with the Wanderer, also with Defect and Ironclad playing
   Arcane Form. In all cases the tips were displayed properly on stream

 - rendering of the hitboxes is purposefully not conditioned on:
     (!AbstractDungeon.isScreenUp || PeekButton.isPeeking)
   the decision whether to respect this is left up to the SlayTheRelics mod.
   Hiding the powertips every time a screen comes up might make for a worse
   viewer experience than leaving them on.

First iteration discussed in #484 

<!--
Thanks for contributing to Jorbs's Wanderer Trilogy!

Before sending your PR, we recommend:

* For large or complicated changes, discuss it first at https://discord.gg/jorbs
* Reference any related issues (eg, "fixes #123") in your PR description
* If the change is user-facing, include bullet point(s) in CHANGELOG.md's [Unreleased] section describing the change for players
* If you are a new contributor, welcome! Feel free to add your name to /docs/credits.md in whichever format you'd like to appear!

See CONTRIBUTING.md for more information and guidance, or come ask questions at https://discord.gg/jorbs
-->