### PR TITLE
Add link to API docs for Slay the Relics

### DIFF
--- a/src/main/java/stsjorbsmod/twitch/SlayTheRelicsIntegration.java
+++ b/src/main/java/stsjorbsmod/twitch/SlayTheRelicsIntegration.java
@@ -13,7 +13,8 @@ public class SlayTheRelicsIntegration {
 
     // =============== API for SlayTheRelics for displaying tooltips on Twitch =================
     //
-    // -------> See <INSERT FUTURE LINK TO THE DOCS> for the documentation of this API <--------
+    // For API documentation, see:
+    // https://slaytherelics.xyz/docs/#custom-tooltips-api-for-mods
     //
     // These two properties are read by another mod that sends their contents over to a Twitch extension called
     // SlayTheRelics and they are displayed alongside other tooltips on stream


### PR DESCRIPTION
Follow-up to #485 now that the official docs for the exporter mod are
live, as linked from the Steam workshop page:
<https://steamcommunity.com/sharedfiles/filedetails/?id=1989770578>

wchargin-branch: slay-the-relics-docs-link
