### PR TITLE
Only check card glow in combat to avoid crash when upgrading cards outside of combat

### DIFF
--- a/src/main/java/stsjorbsmod/patches/CardUpgradeGlowCheckPatch.java
+++ b/src/main/java/stsjorbsmod/patches/CardUpgradeGlowCheckPatch.java
@@ -17,7 +17,11 @@ public class CardUpgradeGlowCheckPatch {
         @SpirePostfixPatch
         public static void patch(AbstractCard __this)
         {
-            if (AbstractDungeon.player != null && AbstractDungeon.player.hand != null && AbstractDungeon.getCurrRoom() != null && AbstractDungeon.getCurrRoom().phase == AbstractRoom.RoomPhase.COMBAT) {
+            if (AbstractDungeon.player != null &&
+                AbstractDungeon.player.hand != null &&
+                AbstractDungeon.getCurrRoom() != null &&
+                AbstractDungeon.getCurrRoom().phase == AbstractRoom.RoomPhase.COMBAT)
+            {
                 AbstractDungeon.player.hand.glowCheck();
             }
         }

--- a/src/main/java/stsjorbsmod/patches/CardUpgradeGlowCheckPatch.java
+++ b/src/main/java/stsjorbsmod/patches/CardUpgradeGlowCheckPatch.java
@@ -4,6 +4,7 @@ import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.rooms.AbstractRoom;
 
 // This is for the benefit of the interaction between Warped Tongs and Mania's glow check
 public class CardUpgradeGlowCheckPatch {
@@ -16,7 +17,7 @@ public class CardUpgradeGlowCheckPatch {
         @SpirePostfixPatch
         public static void patch(AbstractCard __this)
         {
-            if (AbstractDungeon.player != null && AbstractDungeon.player.hand != null) {
+            if (AbstractDungeon.player != null && AbstractDungeon.player.hand != null && AbstractDungeon.getCurrRoom().phase == AbstractRoom.RoomPhase.COMBAT) {
                 AbstractDungeon.player.hand.glowCheck();
             }
         }

--- a/src/main/java/stsjorbsmod/patches/CardUpgradeGlowCheckPatch.java
+++ b/src/main/java/stsjorbsmod/patches/CardUpgradeGlowCheckPatch.java
@@ -17,7 +17,7 @@ public class CardUpgradeGlowCheckPatch {
         @SpirePostfixPatch
         public static void patch(AbstractCard __this)
         {
-            if (AbstractDungeon.player != null && AbstractDungeon.player.hand != null && AbstractDungeon.getCurrRoom().phase == AbstractRoom.RoomPhase.COMBAT) {
+            if (AbstractDungeon.player != null && AbstractDungeon.player.hand != null && AbstractDungeon.getCurrRoom() != null && AbstractDungeon.getCurrRoom().phase == AbstractRoom.RoomPhase.COMBAT) {
                 AbstractDungeon.player.hand.glowCheck();
             }
         }


### PR DESCRIPTION
This is my first PR for JorbsMod but I've read the contribution guide and am attempting to follow it. 

Issue: Upgrading a card outside of combat can crash the game (rarely)
Crash log: https://pastebin.com/pEgtsWyP
Key lines from the log (at the very end):
```
java.lang.NullPointerException: null
    at com.megacrit.cardcrawl.cards.AbstractCard.cardPlayable(AbstractCard.java:1010) ~[?:?]
    at com.megacrit.cardcrawl.cards.AbstractCard.canUse(AbstractCard.java:1104) ~[?:?]
    at com.megacrit.cardcrawl.cards.CardGroup.glowCheck(CardGroup.java:440) ~[?:?]
    at stsjorbsmod.patches.CardUpgradeGlowCheckPatch$AbstractCard_upgradeName.patch(CardUpgradeGlowCheckPatch.java:20) ~[JorbsMod.jar:?]
```

`CardUpgradeGlowCheckPatch` seems to trigger a rare crash when upgrading a card outside of combat. From looking at the stack trace above and decompiling the base game, I believe this is because of the logic in the `cardPlayable` function in AbstractCard.java:

```
    public boolean cardPlayable(AbstractMonster m) {
        if ((this.target != AbstractCard.CardTarget.ENEMY && this.target != AbstractCard.CardTarget.SELF_AND_ENEMY || m == null || !m.isDying) && !AbstractDungeon.getMonsters().areMonstersBasicallyDead()) {
            return true;
        } else {
            this.cantUseMessage = null;
            return false;
        }
    }
```

If we get to the `!AbstractDungeon.getMonsters().areMonstersBasicallyDead()` check, and `AbstractDungeon.getMonsters()` is null, this will hit the null reference exception from the logs. 

I'm not entirely sure when `AbstractDungeon.getMonsters()` is null -- I reproduced this once by making a new character, adding a Mayhem to my deck, and going to an upgrade shrine event before even getting the Neow bonus. But I haven't been able to consistently reproduce it after that first time. Others have reported this issue for other events, though -- https://pastebin.com/98vxfNjV is the crash log from an event that upgrades 2-cost cards, which was reported by someone playing a mod I created (the Elementarium).

My proposed fix is straightforward: only run the glow check when in combat. This preserves the functionality of the patch while avoiding any issues casued by calling `glowCheck` outside of combat (and it makes sense to me that it isn't entirely safe to do that -- glow is only meaningful in combat, so the devs wouldn't have tested calling `glowCheck` outside of combat).

I didn't think this fix needed anything in the changelog.