### PR TITLE
Relic stats mod support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Fixed issue where certain character-themed colors would occasionally be transparent (thanks kiooeht for reporting)
 
-### General updates
+### Updates
 
 * Integration with Relic Stats Mod by ForgottenArbiter/Quincunx (thanks wang429)
   * https://steamcommunity.com/sharedfiles/filedetails/?id=2118491069

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Fixed issue where certain character-themed colors would occasionally be transparent (thanks kiooeht for reporting)
 
+### General updates
+
+* Integration with Relic Stats Mod by ForgottenArbiter/Quincunx (thanks wang429)
+  * https://steamcommunity.com/sharedfiles/filedetails/?id=2118491069
+
 ### CULL updates
 
 * Added the Book of Trials (thanks wang429)

--- a/src/main/java/stsjorbsmod/actions/BurningLoseHpAction.java
+++ b/src/main/java/stsjorbsmod/actions/BurningLoseHpAction.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.utility.WaitAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.AbstractPower;
@@ -12,6 +13,7 @@ import com.megacrit.cardcrawl.vfx.combat.FlashAtkImgEffect;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import stsjorbsmod.powers.BurningPower;
+import stsjorbsmod.relics.AlchemistsFireRelic;
 import stsjorbsmod.util.BurningUtils;
 
 /**
@@ -53,6 +55,9 @@ public class BurningLoseHpAction extends AbstractGameAction {
                 AbstractPower p = this.target.getPower(BurningPower.POWER_ID);
                 if (p != null) {
                     p.amount = BurningUtils.calculateNextBurningAmount(source, p.amount);
+                    if(source != null && source.isPlayer && ((AbstractPlayer) source).hasRelic(AlchemistsFireRelic.ID)) {
+                        ((AlchemistsFireRelic) ((AbstractPlayer) source).getRelic(AlchemistsFireRelic.ID)).updateStats(p.amount);
+                    }
 
                     p.updateDescription();
                 }

--- a/src/main/java/stsjorbsmod/actions/relicStats/AoeDamageFollowupStatsAction.java
+++ b/src/main/java/stsjorbsmod/actions/relicStats/AoeDamageFollowupStatsAction.java
@@ -1,0 +1,28 @@
+package stsjorbsmod.actions.relicStats;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+
+import java.util.ArrayList;
+import java.util.function.Consumer;
+
+/**
+ * Adapted from RelicStats mod to prevent dependency on RelicStats mod.
+ * https://github.com/ForgottenArbiter/StsRelicStats/blob/64b1d26453bbd2738216c6b82b2f419c6396147c/src/main/java/relicstats/actions/AoeDamageFollowupAction.java
+ */
+public class AoeDamageFollowupStatsAction extends AbstractGameAction {
+    Consumer<int[]> statTracker;
+    PreAoeDamageStatsAction preAoeDamageStatsAction;
+
+    public AoeDamageFollowupStatsAction(Consumer<int[]> statTracker, PreAoeDamageStatsAction preAoeDamageStatsAction) {
+        this.statTracker = statTracker;
+        this.preAoeDamageStatsAction = preAoeDamageStatsAction;
+        this.actionType = ActionType.DAMAGE;  // So it's not cleared if the damage kills
+    }
+
+    @Override
+    public void update() {
+        statTracker.accept(preAoeDamageStatsAction.getAffectedMonsters().stream().mapToInt(m -> m.lastDamageTaken).toArray());
+        isDone = true;
+    }
+}

--- a/src/main/java/stsjorbsmod/actions/relicStats/PreAoeDamageStatsAction.java
+++ b/src/main/java/stsjorbsmod/actions/relicStats/PreAoeDamageStatsAction.java
@@ -1,0 +1,33 @@
+package stsjorbsmod.actions.relicStats;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+
+import java.util.ArrayList;
+
+/**
+ * Adapted from RelicStats mod to prevent dependency on RelicStats mod.
+ * https://github.com/ForgottenArbiter/StsRelicStats/blob/64b1d26453bbd2738216c6b82b2f419c6396147c/src/main/java/relicstats/actions/PreAoeDamageAction.java
+ */
+public class PreAoeDamageStatsAction extends AbstractGameAction {
+    private ArrayList<AbstractMonster> affectedMonsters;
+
+    public PreAoeDamageStatsAction() {
+        this.affectedMonsters = new ArrayList<>();
+    }
+
+    public void update() {
+        for (AbstractMonster m : AbstractDungeon.getMonsters().monsters) {
+            if (!(m.isDead || m.isDeadOrEscaped() || m.currentHealth <= 0)) {
+                this.affectedMonsters.add(m);
+                m.lastDamageTaken = 0;
+            }
+        }
+        this.isDone = true;
+    }
+
+    public ArrayList<AbstractMonster> getAffectedMonsters() {
+        return this.affectedMonsters;
+    }
+}

--- a/src/main/java/stsjorbsmod/patches/RelicStringsFieldPatch.java
+++ b/src/main/java/stsjorbsmod/patches/RelicStringsFieldPatch.java
@@ -1,0 +1,10 @@
+package stsjorbsmod.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.localization.RelicStrings;
+
+@SpirePatch(clz = RelicStrings.class, method=SpirePatch.CLASS)
+public class RelicStringsFieldPatch {
+    public static SpireField<String[]> STAT_DESCRIPTIONS = new SpireField<>(() -> new String[0]);
+}

--- a/src/main/java/stsjorbsmod/powers/MindGlassPower.java
+++ b/src/main/java/stsjorbsmod/powers/MindGlassPower.java
@@ -4,44 +4,44 @@ import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.DamageAllEnemiesAction;
 import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
-import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.AbstractCreature;
-import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.AbstractPower;
+import stsjorbsmod.actions.relicStats.AoeDamageFollowupStatsAction;
+import stsjorbsmod.actions.relicStats.PreAoeDamageStatsAction;
 import stsjorbsmod.memories.OnModifyMemoriesSubscriber;
-import stsjorbsmod.relics.MindGlassRelic;
+
+import java.util.function.Consumer;
 
 public class MindGlassPower extends CustomJorbsModPower implements OnModifyMemoriesSubscriber {
     public static final StaticPowerInfo STATIC = StaticPowerInfo.Load(MindGlassPower.class);
     public static final String POWER_ID = STATIC.ID;
 
     private int damage;
+    private Consumer<int[]> statTraker;
 
-    public MindGlassPower(AbstractCreature owner, int damage) {
+    public MindGlassPower(AbstractCreature owner, int damage, Consumer<int[]> statTraker) {
         super(STATIC);
 
         this.owner = owner;
         this.damage = damage;
+        this.statTraker = statTraker;
 
         this.updateDescription();
     }
 
     @Override
     public void onGainClarity(String id) {
-        int[] damageMatrix = DamageInfo.createDamageMatrix(damage, true);
-        if (owner.isPlayer && owner instanceof AbstractPlayer && ((AbstractPlayer) owner).hasRelic(MindGlassRelic.ID)) {
-            ((MindGlassRelic) ((AbstractPlayer) owner).getRelic(MindGlassRelic.ID)).updateStats(damageMatrix, true);
-        }
-        AbstractDungeon.actionManager.addToBottom(
-                new DamageAllEnemiesAction(
+        PreAoeDamageStatsAction preAoeDamageStatsAction = new PreAoeDamageStatsAction();
+        addToBot(preAoeDamageStatsAction);
+        addToBot(new DamageAllEnemiesAction(
                         null,
-                        damageMatrix,
+                        DamageInfo.createDamageMatrix(damage, true),
                         DamageInfo.DamageType.NORMAL,
                         // TODO: More impactful and relevant FX. See FlashAtkImgEffect.loadImage() and
                         //  FlashAtkImgEffect.playSound() for usage of AttackEffect in base game.
                         AbstractGameAction.AttackEffect.BLUNT_HEAVY));
-        AbstractDungeon.actionManager.addToBottom(
-                new RemoveSpecificPowerAction(this.owner, this.owner, MindGlassPower.POWER_ID));
+        addToBot(new AoeDamageFollowupStatsAction(statTraker, preAoeDamageStatsAction));
+        addToBot(new RemoveSpecificPowerAction(this.owner, this.owner, MindGlassPower.POWER_ID));
     }
 
     @Override
@@ -51,6 +51,6 @@ public class MindGlassPower extends CustomJorbsModPower implements OnModifyMemor
 
     @Override
     public AbstractPower makeCopy() {
-        return new MindGlassPower(owner, damage);
+        return new MindGlassPower(owner, damage, statTraker);
     }
 }

--- a/src/main/java/stsjorbsmod/powers/MindGlassPower.java
+++ b/src/main/java/stsjorbsmod/powers/MindGlassPower.java
@@ -4,10 +4,12 @@ import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.DamageAllEnemiesAction;
 import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 import stsjorbsmod.memories.OnModifyMemoriesSubscriber;
+import stsjorbsmod.relics.MindGlassRelic;
 
 public class MindGlassPower extends CustomJorbsModPower implements OnModifyMemoriesSubscriber {
     public static final StaticPowerInfo STATIC = StaticPowerInfo.Load(MindGlassPower.class);
@@ -26,10 +28,14 @@ public class MindGlassPower extends CustomJorbsModPower implements OnModifyMemor
 
     @Override
     public void onGainClarity(String id) {
+        int[] damageMatrix = DamageInfo.createDamageMatrix(damage, true);
+        if (owner.isPlayer && owner instanceof AbstractPlayer && ((AbstractPlayer) owner).hasRelic(MindGlassRelic.ID)) {
+            ((MindGlassRelic) ((AbstractPlayer) owner).getRelic(MindGlassRelic.ID)).updateStats(damageMatrix, true);
+        }
         AbstractDungeon.actionManager.addToBottom(
                 new DamageAllEnemiesAction(
                         null,
-                        DamageInfo.createDamageMatrix(damage, true),
+                        damageMatrix,
                         DamageInfo.DamageType.NORMAL,
                         // TODO: More impactful and relevant FX. See FlashAtkImgEffect.loadImage() and
                         //  FlashAtkImgEffect.playSound() for usage of AttackEffect in base game.

--- a/src/main/java/stsjorbsmod/relics/AlchemistsFireRelic.java
+++ b/src/main/java/stsjorbsmod/relics/AlchemistsFireRelic.java
@@ -1,13 +1,16 @@
 package stsjorbsmod.relics;
 
 import com.evacipated.cardcrawl.mod.stslib.relics.ClickableRelic;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.vfx.ThoughtBubble;
 import stsjorbsmod.JorbsMod;
 
-import java.util.function.Function;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 import static stsjorbsmod.JorbsMod.makeID;
 import static stsjorbsmod.characters.Wanderer.Enums.WANDERER_CARD_COLOR;
@@ -15,16 +18,19 @@ import static stsjorbsmod.characters.Wanderer.Enums.WANDERER_CARD_COLOR;
 /**
  * Reduces Burning's falloff rate to 10%
  */
-public class AlchemistsFireRelic extends CustomJorbsModRelic implements ClickableRelic {
+public class AlchemistsFireRelic extends CustomJorbsModRelic implements ClickableRelic, RelicStatsModSupportIntf {
     public static final String ID = JorbsMod.makeID(AlchemistsFireRelic.class);
 
     public static final String[] ON_CLICK = CardCrawlGame.languagePack.getUIString(makeID("AlchemistsFireOnClick")).TEXT;
 
     public static final int BURNING_FALLOFF_RATE = 10;
-    public static final Function<Integer, Integer> CALCULATE_BURNING_AMOUNT = a -> (a * (100 - BURNING_FALLOFF_RATE)) / 100;
+    private static final String STAT_BURNING_KEPT = "Burning Kept: ";
+
+    HashMap<String, Integer> stats = new HashMap<>();
 
     public AlchemistsFireRelic() {
         super(ID, WANDERER_CARD_COLOR, RelicTier.UNCOMMON, LandingSound.MAGICAL);
+        resetStats();
     }
 
     @Override
@@ -34,11 +40,55 @@ public class AlchemistsFireRelic extends CustomJorbsModRelic implements Clickabl
 
     @Override
     public AbstractRelic makeCopy() {
-        return new AlchemistsFireRelic();
+        AlchemistsFireRelic copy = new AlchemistsFireRelic();
+        copy.stats = this.stats;
+        return copy;
+    }
+
+    public int calculateBurningAmount(int amount) {
+        return (amount * (100 - BURNING_FALLOFF_RATE)) / 100;
+    }
+
+    public void updateStats(int amount) {
+        stats.merge(STAT_BURNING_KEPT, amount, Math::addExact);
     }
 
     @Override
     public void onRightClick() {
         AbstractDungeon.effectList.add(new ThoughtBubble(AbstractDungeon.player.dialogX, AbstractDungeon.player.dialogY, ON_CLICK[0], true));
+    }
+
+    @Override
+    public String getStatsDescription() {
+        return STAT_BURNING_KEPT + stats.get(STAT_BURNING_KEPT);
+    }
+
+    @Override
+    public String getExtendedStatsDescription(int totalCombats, int totalTurns) {
+        float burningKept = (float) stats.get(STAT_BURNING_KEPT);
+        return new StringBuilder(getStatsDescription())
+                .append(STAT_PER_TURN)
+                .append(burningKept / totalTurns)
+                .append(STAT_PER_COMBAT)
+                .append(burningKept / totalCombats)
+                .toString();
+    }
+
+    @Override
+    public void resetStats() {
+        stats.put(STAT_BURNING_KEPT, 0);
+    }
+
+    @Override
+    public Object getStatsToSave() {
+        ArrayList<Integer> statsToSave = new ArrayList<>();
+        statsToSave.add(stats.get(STAT_BURNING_KEPT));
+        return statsToSave;
+    }
+
+    @Override
+    public void setStatsOnLoad(JsonElement jsonElement) {
+        JsonArray jsonArray = jsonElement.getAsJsonArray();
+        stats.put(STAT_BURNING_KEPT, jsonArray.get(0).getAsInt());
     }
 }

--- a/src/main/java/stsjorbsmod/relics/AlchemistsFireRelic.java
+++ b/src/main/java/stsjorbsmod/relics/AlchemistsFireRelic.java
@@ -1,6 +1,7 @@
 package stsjorbsmod.relics;
 
 import com.evacipated.cardcrawl.mod.stslib.relics.ClickableRelic;
+import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -38,13 +39,6 @@ public class AlchemistsFireRelic extends CustomJorbsModRelic implements Clickabl
         this.flash();
     }
 
-    @Override
-    public AbstractRelic makeCopy() {
-        AlchemistsFireRelic copy = new AlchemistsFireRelic();
-        copy.stats = this.stats;
-        return copy;
-    }
-
     public int calculateBurningAmount(int amount) {
         return (amount * (100 - BURNING_FALLOFF_RATE)) / 100;
     }
@@ -80,15 +74,21 @@ public class AlchemistsFireRelic extends CustomJorbsModRelic implements Clickabl
     }
 
     @Override
-    public Object getStatsToSave() {
+    public JsonElement onSaveStats() {
+        // An array makes more sense if you want to store more than one stat
+        Gson gson = new Gson();
         ArrayList<Integer> statsToSave = new ArrayList<>();
         statsToSave.add(stats.get(STAT_BURNING_KEPT));
-        return statsToSave;
+        return gson.toJsonTree(statsToSave);
     }
 
     @Override
-    public void setStatsOnLoad(JsonElement jsonElement) {
-        JsonArray jsonArray = jsonElement.getAsJsonArray();
-        stats.put(STAT_BURNING_KEPT, jsonArray.get(0).getAsInt());
+    public void onLoadStats(JsonElement jsonElement) {
+        if (jsonElement != null) {
+            JsonArray jsonArray = jsonElement.getAsJsonArray();
+            stats.put(STAT_BURNING_KEPT, jsonArray.get(0).getAsInt());
+        } else {
+            resetStats();
+        }
     }
 }

--- a/src/main/java/stsjorbsmod/relics/AlchemistsFireRelic.java
+++ b/src/main/java/stsjorbsmod/relics/AlchemistsFireRelic.java
@@ -25,9 +25,9 @@ public class AlchemistsFireRelic extends CustomJorbsModRelic implements Clickabl
     public static final String[] ON_CLICK = CardCrawlGame.languagePack.getUIString(makeID("AlchemistsFireOnClick")).TEXT;
 
     public static final int BURNING_FALLOFF_RATE = 10;
-    private static final String STAT_BURNING_KEPT = "Burning Kept: ";
 
-    HashMap<String, Integer> stats = new HashMap<>();
+    private final String STAT_BURNING_KEPT = DESCRIPTIONS[1];
+    private HashMap<String, Integer> stats = new HashMap<>();
 
     public AlchemistsFireRelic() {
         super(ID, WANDERER_CARD_COLOR, RelicTier.UNCOMMON, LandingSound.MAGICAL);
@@ -53,18 +53,24 @@ public class AlchemistsFireRelic extends CustomJorbsModRelic implements Clickabl
     }
 
     @Override
+    public AbstractRelic makeCopy() {
+        AlchemistsFireRelic copy = (AlchemistsFireRelic) super.makeCopy();
+        copy.stats = stats;
+        return copy;
+    }
+
+    @Override
     public String getStatsDescription() {
-        return STAT_BURNING_KEPT + stats.get(STAT_BURNING_KEPT);
+        return String.format(STAT_BURNING_KEPT, stats.get(STAT_BURNING_KEPT));
     }
 
     @Override
     public String getExtendedStatsDescription(int totalCombats, int totalTurns) {
         float burningKept = (float) stats.get(STAT_BURNING_KEPT);
-        return new StringBuilder(getStatsDescription())
-                .append(STAT_PER_TURN)
-                .append(burningKept / totalTurns)
-                .append(STAT_PER_COMBAT)
-                .append(burningKept / totalCombats)
+        return new StringBuilder()
+                .append(getStatsDescription())
+                .append(String.format(STAT_PER_TURN, STATS_FORMAT.format(burningKept / Math.max(totalTurns, 1))))
+                .append(String.format(STAT_PER_COMBAT, STATS_FORMAT.format(burningKept / Math.max(totalCombats, 1))))
                 .toString();
     }
 

--- a/src/main/java/stsjorbsmod/relics/CustomJorbsModRelic.java
+++ b/src/main/java/stsjorbsmod/relics/CustomJorbsModRelic.java
@@ -3,11 +3,15 @@ package stsjorbsmod.relics;
 import basemod.abstracts.CustomRelic;
 import com.badlogic.gdx.graphics.Texture;
 import com.megacrit.cardcrawl.cards.AbstractCard.CardColor;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
 import stsjorbsmod.JorbsMod;
 import stsjorbsmod.util.TextureLoader;
 
+import java.util.HashMap;
+
 public abstract class CustomJorbsModRelic extends CustomRelic {
     public final CardColor relicColor;
+    protected final HashMap<String, Integer> stats = new HashMap<>();
 
     private static Texture relicTextureFromId(String id) {
         String unprefixedId = id.replace(JorbsMod.MOD_ID + ":","");
@@ -37,5 +41,12 @@ public abstract class CustomJorbsModRelic extends CustomRelic {
     @Override
     public String getUpdatedDescription() {
         return DESCRIPTIONS[0].replaceAll(JorbsMod.MOD_ID + ":", "#y");
+    }
+
+    @Override
+    public AbstractRelic makeCopy() {
+        CustomJorbsModRelic copy = (CustomJorbsModRelic) super.makeCopy();
+        copy.stats.putAll(stats);
+        return copy;
     }
 }

--- a/src/main/java/stsjorbsmod/relics/CustomJorbsModRelic.java
+++ b/src/main/java/stsjorbsmod/relics/CustomJorbsModRelic.java
@@ -3,15 +3,11 @@ package stsjorbsmod.relics;
 import basemod.abstracts.CustomRelic;
 import com.badlogic.gdx.graphics.Texture;
 import com.megacrit.cardcrawl.cards.AbstractCard.CardColor;
-import com.megacrit.cardcrawl.relics.AbstractRelic;
 import stsjorbsmod.JorbsMod;
 import stsjorbsmod.util.TextureLoader;
 
-import java.util.HashMap;
-
 public abstract class CustomJorbsModRelic extends CustomRelic {
     public final CardColor relicColor;
-    protected final HashMap<String, Integer> stats = new HashMap<>();
 
     private static Texture relicTextureFromId(String id) {
         String unprefixedId = id.replace(JorbsMod.MOD_ID + ":","");
@@ -41,12 +37,5 @@ public abstract class CustomJorbsModRelic extends CustomRelic {
     @Override
     public String getUpdatedDescription() {
         return DESCRIPTIONS[0].replaceAll(JorbsMod.MOD_ID + ":", "#y");
-    }
-
-    @Override
-    public AbstractRelic makeCopy() {
-        CustomJorbsModRelic copy = (CustomJorbsModRelic) super.makeCopy();
-        copy.stats.putAll(stats);
-        return copy;
     }
 }

--- a/src/main/java/stsjorbsmod/relics/GrimoireRelic.java
+++ b/src/main/java/stsjorbsmod/relics/GrimoireRelic.java
@@ -22,8 +22,8 @@ public class GrimoireRelic extends CustomJorbsModRelic implements RelicStatsModS
     public static final String ID = JorbsMod.makeID(GrimoireRelic.class);
 
     private static final int HEAL_PER_CLARITY = 1;
-    private static final String STAT_AMOUNT_HEALED = "Amount Healed: ";
 
+    private final String STAT_AMOUNT_HEALED = DESCRIPTIONS[1];
     private HashMap<String, Integer> stats = new HashMap<>();
 
     public GrimoireRelic() {
@@ -55,18 +55,24 @@ public class GrimoireRelic extends CustomJorbsModRelic implements RelicStatsModS
     }
 
     @Override
+    public AbstractRelic makeCopy() {
+        GrimoireRelic copy = (GrimoireRelic) super.makeCopy();
+        copy.stats = stats;
+        return copy;
+    }
+
+    @Override
     public String getStatsDescription() {
-        return STAT_AMOUNT_HEALED + stats.get(STAT_AMOUNT_HEALED);
+        return String.format(STAT_AMOUNT_HEALED, stats.get(STAT_AMOUNT_HEALED));
     }
 
     @Override
     public String getExtendedStatsDescription(int totalCombats, int totalTurns) {
         float amountHealed = (float) stats.get(STAT_AMOUNT_HEALED);
-        return new StringBuilder(getStatsDescription())
-                .append(STAT_PER_TURN)
-                .append(amountHealed / totalTurns)
-                .append(STAT_PER_COMBAT)
-                .append(amountHealed / totalCombats)
+        return new StringBuilder()
+                .append(getStatsDescription())
+                .append(String.format(STAT_PER_TURN, STATS_FORMAT.format(amountHealed / Math.max(totalTurns, 1))))
+                .append(String.format(STAT_PER_COMBAT, STATS_FORMAT.format(amountHealed / Math.max(totalCombats, 1))))
                 .toString();
     }
 

--- a/src/main/java/stsjorbsmod/relics/GrimoireRelic.java
+++ b/src/main/java/stsjorbsmod/relics/GrimoireRelic.java
@@ -1,23 +1,33 @@
 package stsjorbsmod.relics;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
 import stsjorbsmod.JorbsMod;
 import stsjorbsmod.actions.RememberSpecificMemoryAction;
 import stsjorbsmod.memories.MemoryManager;
 import stsjorbsmod.memories.PatienceMemory;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+
 import static stsjorbsmod.characters.Wanderer.Enums.WANDERER_CARD_COLOR;
 
 // Start each fight remembering Patience. At the end of each fight, gain 1hp per Clarity.
-public class GrimoireRelic extends CustomJorbsModRelic {
+public class GrimoireRelic extends CustomJorbsModRelic implements RelicStatsModSupportIntf {
     public static final String ID = JorbsMod.makeID(GrimoireRelic.class);
 
     private static final int HEAL_PER_CLARITY = 1;
+    private static final String STAT_AMOUNT_HEALED = "Amount Healed: ";
+
+    private HashMap<String, Integer> stats = new HashMap<>();
 
     public GrimoireRelic() {
         super(ID, WANDERER_CARD_COLOR, RelicTier.STARTER, LandingSound.MAGICAL);
+        resetStats();
     }
 
     @Override
@@ -37,7 +47,50 @@ public class GrimoireRelic extends CustomJorbsModRelic {
         AbstractPlayer p = AbstractDungeon.player;
 
         if (p.currentHealth > 0) {
-            p.heal(MemoryManager.forPlayer(p).countCurrentClarities() * HEAL_PER_CLARITY);
+            int healAmount = MemoryManager.forPlayer(p).countCurrentClarities() * HEAL_PER_CLARITY;
+            p.heal(healAmount);
+            stats.merge(STAT_AMOUNT_HEALED, healAmount, Math::addExact);
         }
+    }
+
+    @Override
+    public AbstractRelic makeCopy() {
+        GrimoireRelic copy = new GrimoireRelic();
+        copy.stats = this.stats;
+        return copy;
+    }
+
+    @Override
+    public String getStatsDescription() {
+        return STAT_AMOUNT_HEALED + stats.get(STAT_AMOUNT_HEALED);
+    }
+
+    @Override
+    public String getExtendedStatsDescription(int totalCombats, int totalTurns) {
+        float amountHealed = (float) stats.get(STAT_AMOUNT_HEALED);
+        return new StringBuilder(getStatsDescription())
+                .append(STAT_PER_TURN)
+                .append(amountHealed / totalTurns)
+                .append(STAT_PER_COMBAT)
+                .append(amountHealed / totalCombats)
+                .toString();
+    }
+
+    @Override
+    public void resetStats() {
+        stats.put(STAT_AMOUNT_HEALED, 0);
+    }
+
+    @Override
+    public Object getStatsToSave() {
+        ArrayList<Integer> statsToSave = new ArrayList<>();
+        statsToSave.add(stats.get(STAT_AMOUNT_HEALED));
+        return statsToSave;
+    }
+
+    @Override
+    public void setStatsOnLoad(JsonElement jsonElement) {
+        JsonArray jsonArray = jsonElement.getAsJsonArray();
+        stats.put(STAT_AMOUNT_HEALED, jsonArray.get(0).getAsInt());
     }
 }

--- a/src/main/java/stsjorbsmod/relics/GrimoireRelic.java
+++ b/src/main/java/stsjorbsmod/relics/GrimoireRelic.java
@@ -1,5 +1,6 @@
 package stsjorbsmod.relics;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
@@ -54,13 +55,6 @@ public class GrimoireRelic extends CustomJorbsModRelic implements RelicStatsModS
     }
 
     @Override
-    public AbstractRelic makeCopy() {
-        GrimoireRelic copy = new GrimoireRelic();
-        copy.stats = this.stats;
-        return copy;
-    }
-
-    @Override
     public String getStatsDescription() {
         return STAT_AMOUNT_HEALED + stats.get(STAT_AMOUNT_HEALED);
     }
@@ -82,15 +76,21 @@ public class GrimoireRelic extends CustomJorbsModRelic implements RelicStatsModS
     }
 
     @Override
-    public Object getStatsToSave() {
+    public JsonElement onSaveStats() {
+        // An array makes more sense if you want to store more than one stat
+        Gson gson = new Gson();
         ArrayList<Integer> statsToSave = new ArrayList<>();
         statsToSave.add(stats.get(STAT_AMOUNT_HEALED));
-        return statsToSave;
+        return gson.toJsonTree(statsToSave);
     }
 
     @Override
-    public void setStatsOnLoad(JsonElement jsonElement) {
-        JsonArray jsonArray = jsonElement.getAsJsonArray();
-        stats.put(STAT_AMOUNT_HEALED, jsonArray.get(0).getAsInt());
+    public void onLoadStats(JsonElement jsonElement) {
+        if (jsonElement != null) {
+            JsonArray jsonArray = jsonElement.getAsJsonArray();
+            stats.put(STAT_AMOUNT_HEALED, jsonArray.get(0).getAsInt());
+        } else {
+            resetStats();
+        }
     }
 }

--- a/src/main/java/stsjorbsmod/relics/MetronomeRelic.java
+++ b/src/main/java/stsjorbsmod/relics/MetronomeRelic.java
@@ -1,5 +1,6 @@
 package stsjorbsmod.relics;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import stsjorbsmod.JorbsMod;
@@ -58,15 +59,21 @@ public class MetronomeRelic extends CustomJorbsModRelic implements RelicStatsMod
     }
 
     @Override
-    public Object getStatsToSave() {
+    public JsonElement onSaveStats() {
+        // An array makes more sense if you want to store more than one stat
+        Gson gson = new Gson();
         ArrayList<Integer> statsToSave = new ArrayList<>();
         statsToSave.add(stats.get(STAT_MANIFEST_REDUCED));
-        return statsToSave;
+        return gson.toJsonTree(statsToSave);
     }
 
     @Override
-    public void setStatsOnLoad(JsonElement jsonElement) {
-        JsonArray jsonArray = jsonElement.getAsJsonArray();
-        stats.put(STAT_MANIFEST_REDUCED, jsonArray.get(0).getAsInt());
+    public void onLoadStats(JsonElement jsonElement) {
+        if (jsonElement != null) {
+            JsonArray jsonArray = jsonElement.getAsJsonArray();
+            stats.put(STAT_MANIFEST_REDUCED, jsonArray.get(0).getAsInt());
+        } else {
+            resetStats();
+        }
     }
 }

--- a/src/main/java/stsjorbsmod/relics/MetronomeRelic.java
+++ b/src/main/java/stsjorbsmod/relics/MetronomeRelic.java
@@ -1,15 +1,25 @@
 package stsjorbsmod.relics;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import stsjorbsmod.JorbsMod;
 import stsjorbsmod.actions.IncreaseManifestAction;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+
 import static stsjorbsmod.characters.Cull.Enums.CULL_CARD_COLOR;
 
-public class MetronomeRelic extends CustomJorbsModRelic {
+public class MetronomeRelic extends CustomJorbsModRelic implements RelicStatsModSupportIntf {
     public static final String ID = JorbsMod.makeID(MetronomeRelic.class);
+
+    private static final String STAT_MANIFEST_REDUCED = "Manifest Reduced: ";
+
+    private HashMap<String, Integer> stats = new HashMap<>();
 
     public MetronomeRelic() {
         super(ID, CULL_CARD_COLOR, RelicTier.UNCOMMON, LandingSound.CLINK);
+        resetStats();
     }
 
     @Override
@@ -22,6 +32,41 @@ public class MetronomeRelic extends CustomJorbsModRelic {
             this.counter = 0;
             flash();
             addToBot(new IncreaseManifestAction(-1));
+            stats.merge(STAT_MANIFEST_REDUCED, 1, Math::addExact);
         }
+    }
+
+    @Override
+    public String getStatsDescription() {
+        return STAT_MANIFEST_REDUCED + stats.get(STAT_MANIFEST_REDUCED);
+    }
+
+    @Override
+    public String getExtendedStatsDescription(int totalCombats, int totalTurns) {
+        float manifestReduced = (float) stats.get(STAT_MANIFEST_REDUCED);
+        return new StringBuilder(getStatsDescription())
+                .append(STAT_PER_TURN)
+                .append(manifestReduced / totalTurns)
+                .append(STAT_PER_COMBAT)
+                .append(manifestReduced / totalCombats)
+                .toString();
+    }
+
+    @Override
+    public void resetStats() {
+        stats.put(STAT_MANIFEST_REDUCED, 0);
+    }
+
+    @Override
+    public Object getStatsToSave() {
+        ArrayList<Integer> statsToSave = new ArrayList<>();
+        statsToSave.add(stats.get(STAT_MANIFEST_REDUCED));
+        return statsToSave;
+    }
+
+    @Override
+    public void setStatsOnLoad(JsonElement jsonElement) {
+        JsonArray jsonArray = jsonElement.getAsJsonArray();
+        stats.put(STAT_MANIFEST_REDUCED, jsonArray.get(0).getAsInt());
     }
 }

--- a/src/main/java/stsjorbsmod/relics/MetronomeRelic.java
+++ b/src/main/java/stsjorbsmod/relics/MetronomeRelic.java
@@ -3,6 +3,7 @@ package stsjorbsmod.relics;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
 import stsjorbsmod.JorbsMod;
 import stsjorbsmod.actions.IncreaseManifestAction;
 
@@ -14,8 +15,7 @@ import static stsjorbsmod.characters.Cull.Enums.CULL_CARD_COLOR;
 public class MetronomeRelic extends CustomJorbsModRelic implements RelicStatsModSupportIntf {
     public static final String ID = JorbsMod.makeID(MetronomeRelic.class);
 
-    private static final String STAT_MANIFEST_REDUCED = "Manifest Reduced: ";
-
+    private final String STAT_MANIFEST_REDUCED = DESCRIPTIONS[1];
     private HashMap<String, Integer> stats = new HashMap<>();
 
     public MetronomeRelic() {
@@ -38,18 +38,24 @@ public class MetronomeRelic extends CustomJorbsModRelic implements RelicStatsMod
     }
 
     @Override
+    public AbstractRelic makeCopy() {
+        MetronomeRelic copy = (MetronomeRelic) super.makeCopy();
+        copy.stats = stats;
+        return copy;
+    }
+
+    @Override
     public String getStatsDescription() {
-        return STAT_MANIFEST_REDUCED + stats.get(STAT_MANIFEST_REDUCED);
+        return String.format(STAT_MANIFEST_REDUCED, stats.get(STAT_MANIFEST_REDUCED));
     }
 
     @Override
     public String getExtendedStatsDescription(int totalCombats, int totalTurns) {
         float manifestReduced = (float) stats.get(STAT_MANIFEST_REDUCED);
-        return new StringBuilder(getStatsDescription())
-                .append(STAT_PER_TURN)
-                .append(manifestReduced / totalTurns)
-                .append(STAT_PER_COMBAT)
-                .append(manifestReduced / totalCombats)
+        return new StringBuilder()
+                .append(getStatsDescription())
+                .append(String.format(STAT_PER_TURN, STATS_FORMAT.format(manifestReduced / Math.max(totalTurns, 1))))
+                .append(String.format(STAT_PER_COMBAT, STATS_FORMAT.format(manifestReduced / Math.max(totalCombats, 1))))
                 .toString();
     }
 

--- a/src/main/java/stsjorbsmod/relics/MindGlassRelic.java
+++ b/src/main/java/stsjorbsmod/relics/MindGlassRelic.java
@@ -2,6 +2,7 @@ package stsjorbsmod.relics;
 
 import basemod.BaseMod;
 import basemod.interfaces.PostUpdateSubscriber;
+import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
@@ -30,8 +31,6 @@ public class MindGlassRelic extends CustomJorbsModRelic implements OnModifyMemor
     private static final int TEN_CLARITY_DAMAGE = 100;
     private static final String STAT_DAMAGE_DEALT = "Damage Dealt: ";
     private static final String STAT_TEN_CLARITIES = "Times Ten Clarities Gained: ";
-
-    private HashMap<String, Integer> stats = new HashMap<>();
 
     public MindGlassRelic() {
         super(ID, WANDERER_CARD_COLOR, RelicTier.UNCOMMON, LandingSound.CLINK);
@@ -122,6 +121,7 @@ public class MindGlassRelic extends CustomJorbsModRelic implements OnModifyMemor
                 .append(damageDealt / totalTurns)
                 .append(STAT_PER_COMBAT)
                 .append(damageDealt / totalCombats)
+                .append(" NL ")
                 .append(STAT_TEN_CLARITIES)
                 .append((int) tenClarities)
                 .append(STAT_PER_TURN)
@@ -137,17 +137,23 @@ public class MindGlassRelic extends CustomJorbsModRelic implements OnModifyMemor
     }
 
     @Override
-    public Object getStatsToSave() {
+    public JsonElement onSaveStats() {
+        // An array makes more sense if you want to store more than one stat
+        Gson gson = new Gson();
         ArrayList<Integer> statsToSave = new ArrayList<>();
         statsToSave.add(stats.get(STAT_DAMAGE_DEALT));
         statsToSave.add(stats.get(STAT_TEN_CLARITIES));
-        return statsToSave;
+        return gson.toJsonTree(statsToSave);
     }
 
     @Override
-    public void setStatsOnLoad(JsonElement jsonElement) {
-        JsonArray jsonArray = jsonElement.getAsJsonArray();
-        stats.put(STAT_DAMAGE_DEALT, jsonArray.get(0).getAsInt());
-        stats.put(STAT_TEN_CLARITIES, jsonArray.get(0).getAsInt());
+    public void onLoadStats(JsonElement jsonElement) {
+        if (jsonElement != null) {
+            JsonArray jsonArray = jsonElement.getAsJsonArray();
+            stats.put(STAT_DAMAGE_DEALT, jsonArray.get(0).getAsInt());
+            stats.put(STAT_TEN_CLARITIES, jsonArray.get(0).getAsInt());
+        } else {
+            resetStats();
+        }
     }
 }

--- a/src/main/java/stsjorbsmod/relics/MindPalaceRelic.java
+++ b/src/main/java/stsjorbsmod/relics/MindPalaceRelic.java
@@ -4,7 +4,6 @@ import basemod.abstracts.CustomSavable;
 import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import stsjorbsmod.JorbsMod;
-import stsjorbsmod.actions.GainSpecificClarityAction;
 import stsjorbsmod.memories.MemoryManager;
 import stsjorbsmod.memories.OnModifyMemoriesSubscriber;
 

--- a/src/main/java/stsjorbsmod/relics/RelicStatsModSupportIntf.java
+++ b/src/main/java/stsjorbsmod/relics/RelicStatsModSupportIntf.java
@@ -1,16 +1,25 @@
 package stsjorbsmod.relics;
 
 import com.google.gson.JsonElement;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
+
+import java.text.DecimalFormat;
+
+import static stsjorbsmod.JorbsMod.makeID;
 
 /**
  * This interface is meant to help enforce support for the Relic Stats Mod by ForgottenArbiter/Quincunx
  * Steam workshop page: https://steamcommunity.com/sharedfiles/filedetails/?id=2118491069
  * GitHub page: https://github.com/ForgottenArbiter/StsRelicStats
+ * For whatever reason, these methods must be defined in the relic class, not any parent class.
  */
 interface RelicStatsModSupportIntf {
-    String STAT_PER_TURN = " NL Per turn: ";
-    String STAT_PER_COMBAT = " NL Per combat: ";
+    String[] STAT_TEXTS = CardCrawlGame.languagePack.getUIString(makeID("RelicStatsModSupportIntf")).TEXT;
+    String STAT_PER_TURN = STAT_TEXTS[0];
+    String STAT_PER_COMBAT = STAT_TEXTS[1];
+    // Relic Stats truncates these extended stats to 3 decimal places, so we do the same
+    DecimalFormat STATS_FORMAT = new DecimalFormat("#.###");
 
     /**
      * The string which is displayed in the stats window (uses Default StS formatting, like NL for a line break)

--- a/src/main/java/stsjorbsmod/relics/RelicStatsModSupportIntf.java
+++ b/src/main/java/stsjorbsmod/relics/RelicStatsModSupportIntf.java
@@ -1,6 +1,5 @@
 package stsjorbsmod.relics;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
 
@@ -28,27 +27,14 @@ interface RelicStatsModSupportIntf {
      */
     void resetStats();
 
-    Object getStatsToSave();
+    JsonElement onSaveStats();
 
-    default JsonElement onSaveStats() {
-        // An array makes more sense if you want to store more than one stat
-        Gson gson = new Gson();
-        return gson.toJsonTree(getStatsToSave());
-    }
-
-    void setStatsOnLoad(JsonElement jsonElement);
-
-    default void onLoadStats(JsonElement jsonElement) {
-        if (jsonElement != null) {
-            setStatsOnLoad(jsonElement);
-        } else {
-            resetStats();
-        }
-    }
+    void onLoadStats(JsonElement jsonElement);
 
     /**
      * Relic Stats will always query the stats from the instance passed to BaseMod.addRelic()
      * Therefore, need to make sure all copies share the same stats by copying the stats.
+     * This has been written to be handled in CustomJorbsModRelic
      */
     AbstractRelic makeCopy();
 }

--- a/src/main/java/stsjorbsmod/relics/RelicStatsModSupportIntf.java
+++ b/src/main/java/stsjorbsmod/relics/RelicStatsModSupportIntf.java
@@ -1,0 +1,54 @@
+package stsjorbsmod.relics;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+
+/**
+ * This interface is meant to help enforce support for the Relic Stats Mod by ForgottenArbiter/Quincunx
+ * Steam workshop page: https://steamcommunity.com/sharedfiles/filedetails/?id=2118491069
+ * GitHub page: https://github.com/ForgottenArbiter/StsRelicStats
+ */
+interface RelicStatsModSupportIntf {
+    String STAT_PER_TURN = " NL Per turn: ";
+    String STAT_PER_COMBAT = " NL Per combat: ";
+
+    /**
+     * The string which is displayed in the stats window (uses Default StS formatting, like NL for a line break)
+     */
+    String getStatsDescription();
+
+    /**
+     * The string which is displayed if extended stats are turned on (per combat, per turn)
+     */
+    String getExtendedStatsDescription(int totalCombats, int totalTurns);
+
+    /**
+     * Called to reset your relic's stats for a new run
+     */
+    void resetStats();
+
+    Object getStatsToSave();
+
+    default JsonElement onSaveStats() {
+        // An array makes more sense if you want to store more than one stat
+        Gson gson = new Gson();
+        return gson.toJsonTree(getStatsToSave());
+    }
+
+    void setStatsOnLoad(JsonElement jsonElement);
+
+    default void onLoadStats(JsonElement jsonElement) {
+        if (jsonElement != null) {
+            setStatsOnLoad(jsonElement);
+        } else {
+            resetStats();
+        }
+    }
+
+    /**
+     * Relic Stats will always query the stats from the instance passed to BaseMod.addRelic()
+     * Therefore, need to make sure all copies share the same stats by copying the stats.
+     */
+    AbstractRelic makeCopy();
+}

--- a/src/main/java/stsjorbsmod/util/BurningUtils.java
+++ b/src/main/java/stsjorbsmod/util/BurningUtils.java
@@ -7,7 +7,8 @@ import stsjorbsmod.relics.AlchemistsFireRelic;
 public class BurningUtils {
     public static int calculateNextBurningAmount(AbstractCreature source, int baseAmount) {
         if(source != null && source.isPlayer && ((AbstractPlayer) source).hasRelic(AlchemistsFireRelic.ID)) {
-            return AlchemistsFireRelic.CALCULATE_BURNING_AMOUNT.apply(baseAmount);
+            AlchemistsFireRelic relic = (AlchemistsFireRelic) ((AbstractPlayer) source).getRelic(AlchemistsFireRelic.ID);
+            return relic.calculateBurningAmount(baseAmount);
         } else {
             return 2 * baseAmount / 3;
         }

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Relic-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Relic-Strings.json
@@ -3,7 +3,8 @@
     "NAME": "Alchemist's Fire",
     "FLAVOR": "Forca Messi! Forca Messi! Messi Animal!",
     "DESCRIPTIONS": [
-      "Reduces stsjorbsmod:Burning falloff rate to 10% per turn."
+      "Reduces stsjorbsmod:Burning falloff rate to #b10% per turn.",
+      "Burning Saved: #b%1$s"
     ]
   },
   "stsjorbsmod:BookOfTrialsRelic": {
@@ -27,21 +28,25 @@
     "NAME": "Grimoire",
     "FLAVOR": "Is this... familiar?",
     "DESCRIPTIONS": [
-      "At the start of each combat, remember stsjorbsmod:Patience. NL At the end of each combat, heal #b1 HP per stsjorbsmod:Clarity."
+      "At the start of each combat, remember stsjorbsmod:Patience. NL At the end of each combat, heal #b1 HP per stsjorbsmod:Clarity.",
+      "Amount Healed: #b%1$s"
     ]
   },
   "stsjorbsmod:MetronomeRelic": {
     "NAME": "Metronome",
     "FLAVOR": "Tick Tock...Tick Tock",
     "DESCRIPTIONS": [
-      "At the start of every 5th turn, reduce stsjorbsmod:Manifest by 1."
+      "At the start of every #b5th turn, reduce stsjorbsmod:Manifest by #b1.",
+      "Manifest Reduced: #b%1$s"
     ]
   },
   "stsjorbsmod:MindGlassRelic": {
     "NAME": "Mind Glass",
     "FLAVOR": "Press e to e.",
     "DESCRIPTIONS": [
-      "Gaining stsjorbsmod:Clarity deals 3 damage to all enemies. NL Gaining 10 stsjorbsmod:Clarity in the same fight deals 100 damage to all enemies."
+      "Gaining stsjorbsmod:Clarity deals #b3 damage to all enemies. NL Gaining #b10 stsjorbsmod:Clarity in the same fight deals #b100 damage to all enemies.",
+      "Damage Dealt: #b%1$s",
+      " NL Times Gained Ten Clarities: #b%1$s"
     ]
   },
   "stsjorbsmod:MindPalaceRelic": {

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-UI-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-UI-Strings.json
@@ -87,6 +87,12 @@
       "Voiceover Subtitles"
     ]
   },
+  "stsjorbsmod:RelicStatsModSupportIntf": {
+    "TEXT": [
+      " NL Per turn: #b%1$s",
+      " NL Per combat: #b%1$s"
+    ]
+  },
   "stsjorbsmod:SnapCounter": {
     "TEXT": [
       "Fragile Mind",


### PR DESCRIPTION
Supports Relic Stats Mod by ForgottenArbiter/Quincunx
Steam Workshop: https://steamcommunity.com/sharedfiles/filedetails/?id=2118491069
GitHub: https://github.com/ForgottenArbiter/StsRelicStats

Relics with stats:
- Alchemist's Fire: Burning retained because falloff rate was reduced
- Grimoire (relic): Amount healed
- Metronome: Manifest reduced
- Mind Glass: Damage dealt and number of times player gains ten clarities in a single combat

Feel free to comment on other useful stats from other existing relics.