### PR TITLE
ReflectionUtils OpenJDK fix

### DIFF
--- a/src/main/java/stsjorbsmod/powers/MirroredTechniquePower.java
+++ b/src/main/java/stsjorbsmod/powers/MirroredTechniquePower.java
@@ -59,7 +59,7 @@ public class MirroredTechniquePower extends CustomJorbsModPower {
                 if (!m.isDeadOrEscaped() && IntentUtils.isAttackIntent(m.intent)) {
 
                     int multiAmt = 0;
-                    if (ReflectionUtils.getPrivateField(m, AbstractMonster.class, "isMultiDmg")) {
+                    if (ReflectionUtils.getPrivateField(m, AbstractMonster.class, "isMultiDmg").equals(true)) {
                         multiAmt = ReflectionUtils.getPrivateField(m, AbstractMonster.class, "intentMultiAmt");
                     }
                     else {

--- a/src/main/java/stsjorbsmod/powers/MirroredTechniquePower.java
+++ b/src/main/java/stsjorbsmod/powers/MirroredTechniquePower.java
@@ -59,6 +59,7 @@ public class MirroredTechniquePower extends CustomJorbsModPower {
                 if (!m.isDeadOrEscaped() && IntentUtils.isAttackIntent(m.intent)) {
 
                     int multiAmt = 0;
+                    //uses .equals(true) to force getPrivateField to boolean, getting around a compilation error with openJDK
                     if (ReflectionUtils.getPrivateField(m, AbstractMonster.class, "isMultiDmg").equals(true)) {
                         multiAmt = ReflectionUtils.getPrivateField(m, AbstractMonster.class, "intentMultiAmt");
                     }


### PR DESCRIPTION
fixes #562 
changed `ReflectionUtils.getPrivateField(m, AbstractMonster.class, "isMultiDmg")` to use .equals(true) to force getPrivateField to boolean, to get around a compilation error with openJDK