### PR TITLE
Fixing Corner cases with floorCount

### DIFF
--- a/src/main/java/stsjorbsmod/patches/ManifestPatch.java
+++ b/src/main/java/stsjorbsmod/patches/ManifestPatch.java
@@ -75,11 +75,8 @@ public class ManifestPatch {
                 logger.info("Next Floor: " + __this.nextRoom.y );
                 logger.info("Current Floor Count: " + __this.floorNum );
                 
-                //On moving the first floor CurrMapNode is -1 and the game increments floor number by one as expected, so do nothing
-                if(__this.getCurrMapNode().y >= 0){
                 //Otherwise increment floor count by the difference between Current y level and next y level -1 to account for the game's increment by 1
                 __this.floorNum += __this.nextRoom.y-__this.getCurrMapNode().y-1;
-                }
 
                 boolean nextRoomIsEvent = __this.nextRoom != null && __this.nextRoom.room instanceof EventRoom;
                 int startingManifest = (nextRoomIsEvent && AbstractDungeon.player instanceof Cull) ? 1 : 0;

--- a/src/main/java/stsjorbsmod/patches/ManifestPatch.java
+++ b/src/main/java/stsjorbsmod/patches/ManifestPatch.java
@@ -3,6 +3,7 @@ package stsjorbsmod.patches;
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.dungeons.TheEnding;
 import com.megacrit.cardcrawl.map.MapRoomNode;
 import com.megacrit.cardcrawl.rooms.EventRoom;
 import com.megacrit.cardcrawl.saveAndContinue.SaveFile;
@@ -14,7 +15,7 @@ import org.apache.logging.log4j.LogManager;
 
 public class ManifestPatch {
 
-    public static final Logger logger = LogManager.getLogger(LegendaryPatch.class.getName());
+    public static final Logger logger = LogManager.getLogger(ManifestPatch.class.getName());
 
     @SpirePatch(clz = AbstractPlayer.class, method = SpirePatch.CLASS)
     public static class PlayerManifestField {
@@ -75,8 +76,14 @@ public class ManifestPatch {
                 logger.info("Next Floor: " + __this.nextRoom.y );
                 logger.info("Current Floor Count: " + __this.floorNum );
                 
+                /*The chest rooms after the boss are the same y so the formula evaluates to -1 preventing increment without this if
+                  Every act except act 3 puts you at y=-1 before the first room, but act 3 is y=15 resulting in a reset of floor count without the if
+                  The Ending has an issue where boss rooms are always y=15 so it goes from y=2 to y=15 unless you stop the formula from running
+                  */
+                if(__this.nextRoom.y>__this.getCurrMapNode().y && !(__this instanceof TheEnding)){
                 //Otherwise increment floor count by the difference between Current y level and next y level -1 to account for the game's increment by 1
                 __this.floorNum += __this.nextRoom.y-__this.getCurrMapNode().y-1;
+                }
 
                 boolean nextRoomIsEvent = __this.nextRoom != null && __this.nextRoom.room instanceof EventRoom;
                 int startingManifest = (nextRoomIsEvent && AbstractDungeon.player instanceof Cull) ? 1 : 0;


### PR DESCRIPTION
- The chest rooms after the boss are the same y so the formula evaluates to -1 preventing increment without this if
- Every act except act 3 puts you at y=-1 before the first room, but act 3 is y=15 resulting in a reset of floor count without the if
- The Ending has an issue where boss rooms are always y=15 so it goes from y=2 to y=15 unless you stop the formula from running    