### PR TITLE
Focused Rage includes itself in strength gain calculations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,12 @@
 * New art for Double (thanks Newigeg)
 * New art for Exhale (thanks Zyalin)
 
-### CULL balance/design changes
+#### CULL balance/design changes
 
 * Blasphemer: Smites added when drawn 5->4, Blasphemer+ now adds 4 upgraded Smites.
 * Spirit Shield: Cost 1->0, Exhausts. Spirit Shield+ removes Exhaust.
 * Siphon: Now adds 1 Max HP when it kills an enemy in addition to healing 4
+* Focused Rage: Now adds 2(3) Strength for exerting itself. (thanks wang429)
 
 ### Wanderer Updates
 

--- a/src/main/java/stsjorbsmod/cards/cull/FocusedRage.java
+++ b/src/main/java/stsjorbsmod/cards/cull/FocusedRage.java
@@ -34,17 +34,12 @@ public class FocusedRage extends CustomJorbsModCard {
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-        if (magicNumber > 0) {
-            addToBot(new ApplyPowerAction(p, p, new StrengthPower(p, magicNumber)));
-        }
-        else {
-            AbstractDungeon.effectList.add(new ThoughtBubble(AbstractDungeon.player.dialogX, AbstractDungeon.player.dialogY, 3.0F, EXTENDED_DESCRIPTION[1], true));
-        }
+        addToBot(new ApplyPowerAction(p, p, new StrengthPower(p, magicNumber)));
     }
 
     @Override
     protected int calculateBonusMagicNumber() {
-        int bonusMagicNumber = 0;
+        int bonusMagicNumber = urMagicNumber;
         for(AbstractCard c : AbstractDungeon.player.exhaustPile.group) {
             if (ExertedField.exerted.get(c) && !ExertedField.exertedAtStartOfCombat.get(c)) {
                 bonusMagicNumber += urMagicNumber;

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -332,7 +332,7 @@
   },
   "stsjorbsmod:FocusedRage": {
     "NAME": "Focused Rage",
-    "DESCRIPTION": "Gain !stsjorbsmod:UrMagic! Strength for each card stsjorbsmod:Exerted this combat NL (including this card). NL stsjorbsmod:Exert.",
+    "DESCRIPTION": "stsjorbsmod:Exert. NL Gain !stsjorbsmod:UrMagic! Strength for each card stsjorbsmod:Exerted this combat.",
     "EXTENDED_DESCRIPTION": [
       " NL (Applies !M! Strength.)"
     ]

--- a/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
+++ b/src/main/resources/stsjorbsmodResources/localization/eng/JorbsMod-Card-Strings.json
@@ -332,10 +332,9 @@
   },
   "stsjorbsmod:FocusedRage": {
     "NAME": "Focused Rage",
-    "DESCRIPTION": "Gain !stsjorbsmod:UrMagic! Strength for each card stsjorbsmod:Exerted this combat. NL stsjorbsmod:Exert.",
+    "DESCRIPTION": "Gain !stsjorbsmod:UrMagic! Strength for each card stsjorbsmod:Exerted this combat NL (including this card). NL stsjorbsmod:Exert.",
     "EXTENDED_DESCRIPTION": [
-      " NL (Applies !M! Strength.)",
-      "Nothing exerted this combat!"
+      " NL (Applies !M! Strength.)"
     ]
   },
   "stsjorbsmod:ForbiddenGrimoire": {


### PR DESCRIPTION
> focused rage rework somehow (per card exerted this act?) - have it exert first so that it always gives at least a bit of strength

2(3) strength gained for playing itself.