### PR TITLE
Mind glass 10 clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fixed issue where starter deck legendary cards would still be in card pools in act 1 (by Coogrr)
 * Fixed issue with not being able to play cards with Sacrifice if you had 0 energy (thanks LankSSBM)
 * Fixed Assertion card text (thanks LankSSBM)
+* Fixed issue where playing Arcane Form would not trigger Mind Glass relic's 10 clarity damage (thanks wang429)
 
 ### CULL updates
 

--- a/src/main/java/stsjorbsmod/memories/MemoryManager.java
+++ b/src/main/java/stsjorbsmod/memories/MemoryManager.java
@@ -7,9 +7,12 @@ import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.AbstractPower;
+import stsjorbsmod.actions.ConsumerGameAction;
 import stsjorbsmod.characters.Wanderer;
 import stsjorbsmod.patches.PlayerMemoryManagerPatch;
+import stsjorbsmod.powers.MindGlassPower;
 import stsjorbsmod.powers.SnappedPower;
+import stsjorbsmod.relics.MindGlassRelic;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -105,6 +108,11 @@ public class MemoryManager {
         clarity.updateDescription();
         clarity.flash();
         notifyModifyMemories(subscriber -> subscriber.onGainClarity(id));
+        AbstractDungeon.actionManager.addToBottom(new ConsumerGameAction<>(i -> {
+            if (owner.hasPower(MindGlassPower.POWER_ID)) {
+                ((MindGlassPower) owner.getPower(MindGlassPower.POWER_ID)).onGainClarity(i);
+            }
+        }, id));
     }
 
     public void loseClarity(AbstractMemory clarity) {


### PR DESCRIPTION
fixes #549 

Note that 10 clarity damage strike only happens after all clarities are gained.